### PR TITLE
Fix duplicate players and update info

### DIFF
--- a/players.json
+++ b/players.json
@@ -1,659 +1,8662 @@
 [
-  {"id":1, "name":"Lionel Messi", "birthdate":"1987-06-24", "club":"Inter Miami", "league":"MLS", "position":"Forward", "nationality":"Argentina", "past_clubs":["Barcelona", "Paris Saint-Germain"]},
-  {"id":2, "name":"Cristiano Ronaldo", "birthdate":"1985-02-05", "club":"Al Nassr", "league":"Saudi Pro League", "position":"Forward", "nationality":"Portugal", "past_clubs":["Sporting CP", "Manchester United", "Real Madrid", "Juventus"]},
-  {"id":3, "name":"Neymar Jr", "birthdate":"1992-02-05", "club":"Santos", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Barcelona", "Paris Saint-Germain", "Al Hilal"]},
-  {"id":4, "name":"Kylian Mbappé", "birthdate":"1998-12-20", "club":"Real Madrid", "league":"La Liga", "position":"Forward", "nationality":"France", "past_clubs":["Monaco", "Paris Saint-Germain"]},
-  {"id":5, "name":"Erling Haaland", "birthdate":"2000-07-21", "club":"Manchester City", "league":"Premier League", "position":"Forward", "nationality":"Norway", "past_clubs":["Bryne", "Molde", "Red Bull Salzburg", "Borussia Dortmund"]},
-  {"id":6, "name":"Kevin De Bruyne", "birthdate":"1991-06-28", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Belgium", "past_clubs":["Genk", "Chelsea", "Werder Bremen", "Wolfsburg"]},
-  {"id":7, "name":"Karim Benzema", "birthdate":"1987-12-19", "club":"Al-Ittihad", "league":"Saudi Pro League", "position":"Forward", "nationality":"France", "past_clubs":["Lyon", "Real Madrid"]},
-  {"id":8, "name":"Luka Modric", "birthdate":"1985-09-09", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Croatia", "past_clubs":["Dinamo Zagreb", "Tottenham"]},
-  {"id":9, "name":"Robert Lewandowski", "birthdate":"1988-08-21", "club":"Barcelona", "league":"La Liga", "position":"Forward", "nationality":"Poland", "past_clubs":["Znicz Pruszków", "Lech Poznań", "Borussia Dortmund", "Bayern Munich"]},
-  {"id":10, "name":"Vinícius Júnior", "birthdate":"2000-07-12", "club":"Real Madrid", "league":"La Liga", "position":"Winger", "nationality":"Brazil", "past_clubs":["Flamengo"]},
-  {"id":11, "name":"Mohamed Salah", "birthdate":"1992-06-15", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Egypt", "past_clubs":["El Mokawloon", "Basel", "Chelsea", "Fiorentina", "Roma"]},
-  {"id":12, "name":"Harry Kane", "birthdate":"1993-07-28", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"England", "past_clubs":["Tottenham", "Leyton Orient", "Millwall", "Norwich City", "Leicester City"]},
-  {"id":13, "name":"Jude Bellingham", "birthdate":"2003-06-29", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Birmingham City", "Borussia Dortmund"]},
-  {"id":14, "name":"Rodri", "birthdate":"1996-06-22", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Villarreal", "Atlético Madrid"]},
-  {"id":15, "name":"Bruno Fernandes", "birthdate":"1994-09-08", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Novara", "Udinese", "Sampdoria", "Sporting CP"]},
-  {"id":16, "name":"Virgil van Dijk", "birthdate":"1991-07-08", "club":"Liverpool", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Groningen", "Celtic", "Southampton"]},
-  {"id":17, "name":"Joshua Kimmich", "birthdate":"1995-02-08", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["RB Leipzig"]},
-  {"id":18, "name":"Son Heung-min", "birthdate":"1992-07-08", "club":"Tottenham", "league":"Premier League", "position":"Forward", "nationality":"South Korea", "past_clubs":["Hamburg", "Bayer Leverkusen"]},
-  {"id":19, "name":"Pedri", "birthdate":"2002-11-25", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Las Palmas"]},
-  {"id":20, "name":"Phil Foden", "birthdate":"2000-05-28", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":[]},
-  {"id":21, "name":"Sergio Busquets", "birthdate":"1988-07-16", "club":"Inter Miami", "league":"MLS", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Barcelona"]},
-  {"id":22, "name":"Jordi Alba", "birthdate":"1989-03-21", "club":"Inter Miami", "league":"MLS", "position":"Defender", "nationality":"Spain", "past_clubs":["Valencia", "Barcelona"]},
-  {"id":23, "name":"Casemiro", "birthdate":"1992-02-23", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["São Paulo", "Real Madrid", "Porto"]},
-  {"id":24, "name":"Ederson", "birthdate":"1993-08-17", "club":"Manchester City", "league":"Premier League", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Rio Ave", "Benfica"]},
-  {"id":25, "name":"Alisson Becker", "birthdate":"1992-10-02", "club":"Liverpool", "league":"Premier League", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Internacional", "Roma"]},
-  {"id":26, "name":"Manuel Neuer", "birthdate":"1986-03-27", "club":"Bayern Munich", "league":"Bundesliga", "position":"Goalkeeper", "nationality":"Germany", "past_clubs":["Schalke 04"]},
-  {"id":27, "name":"Jan Oblak", "birthdate":"1993-01-07", "club":"Atlético Madrid", "league":"La Liga", "position":"Goalkeeper", "nationality":"Slovenia", "past_clubs":["Olimpija Ljubljana", "Benfica"]},
-  {"id":28, "name":"Giorgio Chiellini", "birthdate":"1984-08-14", "club":"LAFC", "league":"MLS", "position":"Defender", "nationality":"Italy", "past_clubs":["Livorno", "Fiorentina", "Juventus"]},
-  {"id":29, "name":"Leonardo Bonucci", "birthdate":"1987-05-01", "club":"Fenerbahçe", "league":"Süper Lig", "position":"Defender", "nationality":"Italy", "past_clubs":["Inter Milan", "Pisa", "Genoa", "Bari", "Juventus", "Milan", "Union Berlin"]},
-  {"id":30, "name":"Keylor Navas", "birthdate":"1986-12-15", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Goalkeeper", "nationality":"Costa Rica", "past_clubs":["Saprissa", "Albacete", "Levante", "Real Madrid"]},
-  {"id":31, "name":"Raphaël Varane", "birthdate":"1993-04-25", "club":"Manchester United", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Lens", "Real Madrid"]},
-  {"id":32, "name":"Pepe", "birthdate":"1983-02-26", "club":"Porto", "league":"Primeira Liga", "position":"Defender", "nationality":"Portugal", "past_clubs":["Marítimo", "Porto", "Real Madrid", "Beşiktaş"]},
-  {"id":33, "name":"Reece James", "birthdate":"1999-12-08", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Wigan Athletic"]},
-  {"id":34, "name":"David Luiz", "birthdate":"1987-04-22", "club":"Flamengo", "league":"Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Vitória", "Benfica", "Chelsea", "Paris Saint-Germain", "Arsenal"]},
-  {"id":35, "name":"Fernandinho", "birthdate":"1985-05-04", "club":"Athletico Paranaense", "league":"Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Atlético Paranaense", "Shakhtar Donetsk", "Manchester City"]},
-  {"id":36, "name":"Paul Pogba", "birthdate":"1993-03-15", "club":"Free Agent", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Manchester United", "Juventus"]},
-  {"id":37, "name":"N'Golo Kanté", "birthdate":"1991-03-29", "club":"Al Ittihad", "league":"Saudi Pro League", "position":"Midfielder", "nationality":"France", "past_clubs":["Boulogne", "Caen", "Leicester City", "Chelsea"]},
-  {"id":38, "name":"Toni Kroos", "birthdate":"1990-01-04", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bayern Munich", "Bayer Leverkusen"]},
-  {"id":39, "name":"Ivan Rakitić", "birthdate":"1988-03-10", "club":"Sevilla", "league":"La Liga", "position":"Midfielder", "nationality":"Croatia", "past_clubs":["Basel", "Schalke 04", "Sevilla", "Barcelona"]},
-  {"id":40, "name":"Ander Herrera", "birthdate":"1989-08-14", "club":"Athletic Bilbao", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Real Zaragoza", "Athletic Bilbao", "Manchester United", "Paris Saint-Germain"]},
-  {"id":41, "name":"Ángel Di María", "birthdate":"1988-02-14", "club":"Benfica", "league":"Primeira Liga", "position":"Winger", "nationality":"Argentina", "past_clubs":["Rosario Central", "Benfica", "Real Madrid", "Manchester United", "Paris Saint-Germain", "Juventus"]},
-  {"id":42, "name":"Pierre-Emerick Aubameyang", "birthdate":"1989-06-18", "club":"Marseille", "league":"Ligue 1", "position":"Forward", "nationality":"Gabon", "past_clubs":["Milan", "Saint-Étienne", "Borussia Dortmund", "Arsenal", "Barcelona", "Chelsea"]},
-  {"id":43, "name":"Radamel Falcao", "birthdate":"1986-02-10", "club":"Rayo Vallecano", "league":"La Liga", "position":"Forward", "nationality":"Colombia", "past_clubs":["River Plate", "Porto", "Atlético Madrid", "Monaco", "Manchester United", "Chelsea", "Galatasaray"]},
-  {"id":44, "name":"Edinson Cavani", "birthdate":"1987-02-14", "club":"Boca Juniors", "league":"Primera División", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Danubio", "Palermo", "Napoli", "Paris Saint-Germain", "Manchester United", "Valencia"]},
-  {"id":45, "name":"Luis Suárez", "birthdate":"1987-01-24", "club":"Inter Miami", "league":"MLS", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Nacional", "Groningen", "Ajax", "Liverpool", "Barcelona", "Atlético Madrid", "Grêmio"]},
-  {"id":46, "name":"Olivier Giroud", "birthdate":"1986-09-30", "club":"Milan", "league":"Serie A", "position":"Forward", "nationality":"France", "past_clubs":["Grenoble", "Tours", "Montpellier", "Arsenal", "Chelsea"]},
-  {"id":47, "name":"Antoine Griezmann", "birthdate":"1991-03-21", "club":"Atlético Madrid", "league":"La Liga", "position":"Forward", "nationality":"France", "past_clubs":["Real Sociedad", "Atlético Madrid", "Barcelona"]},
-  {"id":48, "name":"Álvaro Morata", "birthdate":"1992-10-23", "club":"Atlético Madrid", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Real Madrid", "Juventus", "Chelsea"]},
-  {"id":49, "name":"Edin Džeko", "birthdate":"1986-03-17", "club":"Fenerbahçe", "league":"Süper Lig", "position":"Forward", "nationality":"Bosnia and Herzegovina", "past_clubs":["Željezničar", "Teplice", "Wolfsburg", "Manchester City", "Roma", "Inter Milan"]},
-  {"id":50, "name":"Thomas Müller", "birthdate":"1989-09-13", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"Germany", "past_clubs":["Bayern Munich"]},
-  {"id":51, "name":"Oliver Kahn", "birthdate":"1969-06-15", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Germany", "past_clubs":["Karlsruhe", "Bayern Munich"]},
-  {"id":52, "name":"Kaká", "birthdate":"1982-04-22", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["São Paulo", "Milan", "Real Madrid", "Orlando City"]},
-  {"id":53, "name":"Clarence Seedorf", "birthdate":"1976-04-01", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Ajax", "Sampdoria", "Real Madrid", "Inter Milan", "Milan", "Botafogo"]},
-  {"id":54, "name":"Andrea Pirlo", "birthdate":"1979-05-19", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Italy", "past_clubs":["Brescia", "Inter Milan", "Reggina", "Milan", "Juventus", "New York City"]},
-  {"id":55, "name":"Frank Lampard", "birthdate":"1978-06-20", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["West Ham", "Swansea City", "Chelsea", "Manchester City", "New York City"]},
-  {"id":56, "name":"Steven Gerrard", "birthdate":"1980-05-30", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Liverpool", "LA Galaxy"]},
-  {"id":57, "name":"Paul Scholes", "birthdate":"1974-11-16", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester United"]},
-  {"id":58, "name":"Ryan Giggs", "birthdate":"1973-11-29", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Wales", "past_clubs":["Manchester United"]},
-  {"id":59, "name":"David Beckham", "birthdate":"1975-05-02", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester United", "Preston North End", "Real Madrid", "LA Galaxy", "Milan", "Paris Saint-Germain"]},
-  {"id":60, "name":"Patrick Vieira", "birthdate":"1976-06-23", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Cannes", "Milan", "Arsenal", "Juventus", "Inter Milan", "Manchester City"]},
-  {"id":61, "name":"Roy Keane", "birthdate":"1971-08-10", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Ireland", "past_clubs":["Cobh Ramblers", "Nottingham Forest", "Manchester United", "Celtic"]},
-  {"id":62, "name":"Michael Ballack", "birthdate":"1976-09-26", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Chemnitzer FC", "Kaiserslautern", "Bayer Leverkusen", "Bayern Munich", "Chelsea"]},
-  {"id":63, "name":"Lothar Matthäus", "birthdate":"1961-03-21", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Borussia Mönchengladbach", "Bayern Munich", "Inter Milan", "New York Red Bulls"]},
-  {"id":64, "name":"Sócrates", "birthdate":"1954-02-19", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Botafogo-SP", "Corinthians", "Fiorentina", "Flamengo", "Santos"]},
-  {"id":65, "name":"Zico", "birthdate":"1953-03-03", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo", "Udinese", "Kashima Antlers"]},
-  {"id":66, "name":"Rui Costa", "birthdate":"1972-03-29", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica", "Fiorentina", "Milan"]},
-  {"id":67, "name":"Deco", "birthdate":"1977-08-27", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Corinthians", "Benfica", "Porto", "Barcelona", "Chelsea", "Fluminense"]},
-  {"id":68, "name":"Gennaro Gattuso", "birthdate":"1978-01-09", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Italy", "past_clubs":["Perugia", "Rangers", "Salernitana", "Milan", "Sion"]},
-  {"id":69, "name":"Iker Muniain", "birthdate":"1992-12-19", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Athletic Bilbao", "Al-Qadisiyah"]},
-  {"id":70, "name":"Bastian Schweinsteiger", "birthdate":"1984-08-01", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bayern Munich", "Manchester United", "Chicago Fire"]},
-  {"id":71, "name":"Javier Mascherano", "birthdate":"1984-06-08", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["River Plate", "Corinthians", "West Ham", "Liverpool", "Barcelona", "Hebei China Fortune", "Estudiantes"]},
-  {"id":72, "name":"Daniele De Rossi", "birthdate":"1983-07-24", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Italy", "past_clubs":["Roma", "Boca Juniors"]},
-  {"id":73, "name":"Arturo Vidal", "birthdate":"1987-05-22", "club":"Colo-Colo", "league":"Primera División", "position":"Midfielder", "nationality":"Chile", "past_clubs":["Colo-Colo", "Bayer Leverkusen", "Juventus", "Bayern Munich", "Barcelona", "Inter Milan", "Flamengo", "Athletico Paranaense"]},
-  {"id":74, "name":"Paulinho", "birthdate":"1988-07-25", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Pão de Açúcar", "Bragantino", "Corinthians", "Tottenham", "Guangzhou Evergrande", "Barcelona", "Al-Ahli", "Al-Taawoun"]},
-  {"id":75, "name":"Fernandão", "birthdate":"1978-03-18", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Goiás", "Olympique Marseille", "Toulouse", "Internacional", "Al-Gharafa", "São Paulo"]},
-  {"id":76, "name":"Fred", "birthdate":"1983-10-03", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["América Mineiro", "Cruzeiro", "Lyon", "Fluminense", "Atlético Mineiro"]},
-  {"id":77, "name":"Diego Forlán", "birthdate":"1979-05-19", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Independiente", "Manchester United", "Villarreal", "Atlético Madrid", "Inter Milan", "Internacional", "Cerezo Osaka", "Peñarol", "Mumbai City", "Kitchee"]},
-  {"id":78, "name":"Hugo Sánchez", "birthdate":"1958-07-11", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Mexico", "past_clubs":["UNAM", "Atlético Madrid", "Real Madrid", "América", "Rayo Vallecano", "Atlante", "Dallas Burn"]},
-  {"id":79, "name":"Romário", "birthdate":"1966-01-29", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "PSV", "Barcelona", "Flamengo", "Valencia", "Al-Sadd", "Miami FC", "Adelaide United", "America-RJ", "Brasiliense"]},
-  {"id":80, "name":"Bebeto", "birthdate":"1964-02-16", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Vitória", "Flamengo", "Vasco da Gama", "Deportivo La Coruña", "Sevilla", "Cruzeiro", "Botafogo", "Toros Neza", "Kashima Antlers", "Al-Ittihad"]},
-  {"id":81, "name":"Careca", "birthdate":"1960-10-05", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Guarani", "São Paulo", "Napoli", "Kashiwa Reysol", "Santos"]},
-  {"id":82, "name":"Jürgen Klinsmann", "birthdate":"1964-07-30", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["Stuttgart", "Inter Milan", "Monaco", "Tottenham", "Bayern Munich", "Sampdoria"]},
-  {"id":83, "name":"Rudi Völler", "birthdate":"1960-04-13", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["1860 Munich", "Werder Bremen", "Roma", "Marseille", "Bayer Leverkusen"]},
-  {"id":84, "name":"Karl-Heinz Rummenigge", "birthdate":"1955-09-25", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["Bayern Munich", "Inter Milan", "Servette"]},
-  {"id":85, "name":"Paolo Rossi", "birthdate":"1956-09-23", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Juventus", "Vicenza", "Perugia", "Milan", "Hellas Verona"]},
-  {"id":86, "name":"Roberto Baggio", "birthdate":"1967-02-18", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Vicenza", "Fiorentina", "Juventus", "Milan", "Bologna", "Inter Milan", "Brescia"]},
-  {"id":87, "name":"Alessandro Del Piero", "birthdate":"1974-11-09", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Padova", "Juventus", "Sydney FC", "Delhi Dynamos"]},
-  {"id":88, "name":"Francesco Totti", "birthdate":"1976-09-27", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Roma"]},
-  {"id":89, "name":"Filippo Inzaghi", "birthdate":"1973-08-09", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Piacenza", "Parma", "Atalanta", "Juventus", "Milan"]},
-  {"id":90, "name":"Hernán Crespo", "birthdate":"1975-07-05", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["River Plate", "Parma", "Lazio", "Inter Milan", "Chelsea", "Milan", "Genoa"]},
-  {"id":91, "name":"Gabriel Batistuta", "birthdate":"1969-02-01", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["Newell's Old Boys", "River Plate", "Boca Juniors", "Fiorentina", "Roma", "Al-Arabi"]},
-  {"id":92, "name":"Claudio Caniggia", "birthdate":"1967-01-09", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["River Plate", "Verona", "Atalanta", "Roma", "Benfica", "Boca Juniors", "Dundee", "Rangers", "Qatar SC"]},
-  {"id":93, "name":"Enzo Francescoli", "birthdate":"1961-11-12", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Montevideo Wanderers", "River Plate", "RC Paris", "Marseille", "Cagliari", "Torino"]},
-  {"id":94, "name":"Obdulio Varela", "birthdate":"1917-09-20", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Montevideo Wanderers", "Peñarol"]},
-  {"id":95, "name":"Teófilo Cubillas", "birthdate":"1949-03-08", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Peru", "past_clubs":["Alianza Lima", "Basel", "Porto", "Fort Lauderdale Strikers"]},
-  {"id":96, "name":"Elias Figueroa", "birthdate":"1946-10-25", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Chile", "past_clubs":["Unión La Calera", "Santiago Wanderers", "Peñarol", "Internacional", "Palmeiras"]},
-  {"id":97, "name":"Iván Zamorano", "birthdate":"1967-01-18", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Chile", "past_clubs":["Cobresal", "St. Gallen", "Sevilla", "Real Madrid", "Inter Milan", "América"]},
-  {"id":98, "name":"Carlos Valderrama", "birthdate":"1961-09-02", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Colombia", "past_clubs":["Unión Magdalena", "Millonarios", "Deportivo Cali", "Montpellier", "Real Valladolid", "Independiente Medellín", "Tampa Bay Mutiny", "Miami Fusion", "Colorado Rapids"]},
-  {"id":99, "name":"René Higuita", "birthdate":"1966-08-27", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Colombia", "past_clubs":["Millonarios", "Atlético Nacional", "Real Valladolid", "Independiente Medellín", "Aucas"]},
-  {"id":100, "name":"Óscar Córdoba", "birthdate":"1970-02-03", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Colombia", "past_clubs":["Deportivo Cali", "América de Cali", "Boca Juniors", "Perugia", "Beşiktaş", "Antalyaspor", "Millonarios"]},
-  {"id":101, "name":"Ronaldinho Gaúcho", "birthdate":"1980-03-21", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Grêmio", "Paris Saint-Germain", "Barcelona", "Milan", "Flamengo", "Atlético Mineiro", "Fluminense", "Querétaro"]},
-  {"id":102, "name":"Rivaldo", "birthdate":"1972-04-19", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Santa Cruz", "Mogi Mirim", "Corinthians", "Palmeiras", "Deportivo La Coruña", "Barcelona", "Milan", "Cruzeiro", "Olympiacos", "AEK Athens", "Bunyodkor", "São Paulo", "Kabuscorp"]},
-  {"id":103, "name":"Ronaldo Nazário", "birthdate":"1976-09-18", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Cruzeiro", "PSV", "Barcelona", "Inter Milan", "Real Madrid", "Milan", "Corinthians"]},
-  {"id":104, "name":"Pelé", "birthdate":"1940-10-23", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santos", "New York Cosmos"]},
-  {"id":105, "name":"Diego Maradona", "birthdate":"1960-10-30", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Argentinos Juniors", "Boca Juniors", "Barcelona", "Napoli", "Sevilla", "Newell's Old Boys"]},
-  {"id":106, "name":"Johan Cruyff", "birthdate":"1947-04-25", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["Ajax", "Barcelona", "Feyenoord", "Los Angeles Aztecs", "Washington Diplomats", "Levante"]},
-  {"id":107, "name":"Franz Beckenbauer", "birthdate":"1945-09-11", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Germany", "past_clubs":["Bayern Munich", "New York Cosmos", "Hamburger SV"]},
-  {"id":108, "name":"Eusébio", "birthdate":"1942-01-25", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Portugal", "past_clubs":["Benfica", "Boston Minutemen", "Monterrey", "Toronto Metros-Croatia", "Beira-Mar", "Las Vegas Quicksilvers", "União de Tomar", "New Jersey Americans"]},
-  {"id":109, "name":"George Best", "birthdate":"1946-05-22", "club":"Deceased", "league":"Sem liga", "position":"Winger", "nationality":"Northern Ireland", "past_clubs":["Manchester United", "Dunstable Town", "Stockport County", "Cork Celtic", "Los Angeles Aztecs", "Fulham", "Fort Lauderdale Strikers", "Hibernian", "San Jose Earthquakes", "Hong Kong Rangers", "Bournemouth", "Brisbane Lions", "Tobermore United"]},
-  {"id":110, "name":"Ferenc Puskás", "birthdate":"1927-04-01", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary", "past_clubs":["Budapest Honvéd", "Real Madrid"]},
-  {"id":111, "name":"Alfredo Di Stéfano", "birthdate":"1926-07-04", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Argentina/Spain", "past_clubs":["River Plate", "Huracán", "Millonarios", "Real Madrid", "Espanyol"]},
-  {"id":112, "name":"Bobby Charlton", "birthdate":"1937-10-11", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester United", "Preston North End"]},
-  {"id":113, "name":"Garrincha", "birthdate":"1933-10-28", "club":"Deceased", "league":"Sem liga", "position":"Winger", "nationality":"Brazil", "past_clubs":["Botafogo", "Corinthians", "Atlético Junior", "Flamengo", "Olaria"]},
-  {"id":114, "name":"Thierry Henry", "birthdate":"1977-08-17", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"France", "past_clubs":["Monaco", "Juventus", "Arsenal", "Barcelona", "New York Red Bulls"]},
-  {"id":115, "name":"Zinedine Zidane", "birthdate":"1972-06-23", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Cannes", "Bordeaux", "Juventus", "Real Madrid"]},
-  {"id":116, "name":"Michel Platini", "birthdate":"1955-06-21", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Nancy", "Saint-Étienne", "Juventus"]},
-  {"id":117, "name":"Eric Cantona", "birthdate":"1966-05-24", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"France", "past_clubs":["Auxerre", "Martigues", "Marseille", "Bordeaux", "Montpellier", "Nîmes", "Leeds United", "Manchester United"]},
-  {"id":118, "name":"Just Fontaine", "birthdate":"1933-08-18", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"France", "past_clubs":["USM Casablanca", "Nice", "Reims"]},
-  {"id":119, "name":"Lev Yashin", "birthdate":"1929-10-22", "club":"Deceased", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Soviet Union", "past_clubs":["Dynamo Moscow"]},
-  {"id":120, "name":"Sándor Kocsis", "birthdate":"1929-09-21", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary", "past_clubs":["Ferencváros", "Budapest Honvéd", "Young Fellows Zürich", "Barcelona"]},
-  {"id":121, "name":"Dixie Dean", "birthdate":"1907-01-22", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"England", "past_clubs":["Tranmere Rovers", "Everton", "Notts County", "Sligo Rovers", "Ashton United", "Hurst"]},
-  {"id":122, "name":"Stanley Matthews", "birthdate":"1915-02-01", "club":"Deceased", "league":"Sem liga", "position":"Winger", "nationality":"England", "past_clubs":["Stoke City", "Blackpool"]},
-  {"id":123, "name":"John Charles", "birthdate":"1931-12-27", "club":"Deceased", "league":"Sem liga", "position":"Forward/Defender", "nationality":"Wales", "past_clubs":["Leeds United", "Juventus", "Roma", "Cardiff City", "Hereford United"]},
-  {"id":124, "name":"Gordon Banks", "birthdate":"1937-12-30", "club":"Deceased", "league":"Sem liga", "position":"Goalkeeper", "nationality":"England", "past_clubs":["Chesterfield", "Leicester City", "Stoke City", "Fort Lauderdale Strikers"]},
-  {"id":125, "name":"Bobby Moore", "birthdate":"1941-04-12", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"England", "past_clubs":["West Ham United", "Fulham", "San Antonio Thunder", "Seattle Sounders", "Carolina Lightnin'"]},
-  {"id":126, "name":"Gerd Müller", "birthdate":"1945-11-03", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["1861 Nördlingen", "Bayern Munich", "Fort Lauderdale Strikers"]},
-  {"id":127, "name":"Marco van Basten", "birthdate":"1964-10-31", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["Ajax", "Milan"]},
-  {"id":128, "name":"Dennis Bergkamp", "birthdate":"1969-05-10", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["Ajax", "Inter Milan", "Arsenal"]},
-  {"id":129, "name":"Johan Neeskens", "birthdate":"1951-09-15", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Ajax", "Barcelona", "Cosmos"]},
-  {"id":130, "name":"Ruud Gullit", "birthdate":"1962-09-01", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["HFC Haarlem", "Feyenoord", "PSV", "Milan", "Sampdoria", "Chelsea"]},
-  {"id":131, "name":"Roland Nilsson", "birthdate":"1963-11-27", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Sweden", "past_clubs":["IFK Göteborg", "Sheffield Wednesday", "Helsingborg", "Coventry City"]},
-  {"id":132, "name":"Henrik Larsson", "birthdate":"1971-09-20", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Sweden", "past_clubs":["Högaborgs BK", "Helsingborg", "Feyenoord", "Celtic", "Barcelona", "Manchester United", "Råå"]},
-  {"id":133, "name":"Sven-Göran Eriksson", "birthdate":"1948-02-05", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Sweden", "past_clubs":["KB Karlskoga", "Degerfors IF", "Örebro SK"]},
-  {"id":134, "name":"Tomas Brolin", "birthdate":"1969-11-29", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Sweden", "past_clubs":["Näsvikens IK", "GIF Sundsvall", "Parma", "Leeds United", "FC Zürich", "Crystal Palace"]},
-  {"id":135, "name":"Glenn Strömberg", "birthdate":"1960-01-05", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Sweden", "past_clubs":["IFK Göteborg", "Benfica", "Atalanta"]},
-  {"id":136, "name":"Gunnar Nordahl", "birthdate":"1921-10-19", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Sweden", "past_clubs":["Hörnefors IF", "IFK Norrköping", "Milan", "Roma"]},
-  {"id":137, "name":"Giacinto Facchetti", "birthdate":"1942-07-18", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"Italy", "past_clubs":["Inter Milan"]},
-  {"id":138, "name":"Franco Baresi", "birthdate":"1960-05-08", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Italy", "past_clubs":["Milan"]},
-  {"id":139, "name":"Giuseppe Meazza", "birthdate":"1910-08-23", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Italy", "past_clubs":["Inter Milan", "Milan", "Juventus", "Varese", "Atalanta"]},
-  {"id":140, "name":"Gianni Rivera", "birthdate":"1943-08-18", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Italy", "past_clubs":["Alessandria", "Milan"]},
-  {"id":141, "name":"Dino Zoff", "birthdate":"1942-02-28", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Italy", "past_clubs":["Udinese", "Mantova", "Napoli", "Juventus"]},
-  {"id":142, "name":"Cafu", "birthdate":"1970-06-07", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo", "Real Zaragoza", "Palmeiras", "Roma", "Milan"]},
-  {"id":143, "name":"Roberto Carlos", "birthdate":"1973-04-10", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["União São João", "Palmeiras", "Inter Milan", "Real Madrid", "Fenerbahçe", "Corinthians", "Anzhi Makhachkala", "Delhi Dynamos"]},
-  {"id":144, "name":"Jairzinho", "birthdate":"1944-12-25", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Botafogo", "Marseille", "Flamengo", "Corinthians", "Fast"]},
-  {"id":145, "name":"Falcão", "birthdate":"1953-10-16", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Internacional", "Roma", "São Paulo"]},
-  {"id":146, "name":"Djalma Santos", "birthdate":"1929-02-27", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Portuguesa", "Palmeiras", "Atlético Paranaense"]},
-  {"id":147, "name":"Nilton Santos", "birthdate":"1925-05-16", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Botafogo"]},
-  {"id":148, "name":"Ademir de Menezes", "birthdate":"1922-11-08", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Sport Recife", "Vasco da Gama", "Fluminense"]},
-  {"id":149, "name":"Leonidas da Silva", "birthdate":"1913-09-06", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Sírio-Libanês", "Bonsucesso", "Flamengo", "Peñarol", "Vasco da Gama", "Botafogo", "São Paulo", "Canto do Rio"]},
-  {"id":150, "name":"Nílton de Sordi", "birthdate":"1931-02-14", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo"]},
-  {"id":151, "name":"Paul Breitner", "birthdate":"1951-09-05", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bayern Munich", "Real Madrid", "Eintracht Braunschweig"]},
-  {"id":152, "name":"Fritz Walter", "birthdate":"1920-10-31", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Kaiserslautern"]},
-  {"id":153, "name":"Uwe Seeler", "birthdate":"1936-11-05", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["Hamburg", "Cork Celtic"]},
-  {"id":154, "name":"Helmut Rahn", "birthdate":"1929-08-16", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Germany", "past_clubs":["SpVgg Altenessen", "Rot-Weiss Essen", "Meidericher SV", "Sportclub Enschede"]},
-  {"id":155, "name":"Berti Vogts", "birthdate":"1946-12-16", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Germany", "past_clubs":["Borussia Mönchengladbach"]},
-  {"id":156, "name":"Ferenc Deák", "birthdate":"1922-01-16", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary", "past_clubs":["Szentlőrinci AC", "Ferencváros", "Fiorentina", "Újpesti Dózsa"]},
-  {"id":157, "name":"József Bozsik", "birthdate":"1925-11-28", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Hungary", "past_clubs":["Budapest Honvéd"]},
-  {"id":158, "name":"Florian Albert", "birthdate":"1941-09-15", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary", "past_clubs":["Ferencváros"]},
-  {"id":159, "name":"Zoltán Czibor", "birthdate":"1929-08-23", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary", "past_clubs":["Komárom", "Ferencváros", "Budapest Honvéd", "Barcelona", "Espanyol"]},
-  {"id":160, "name":"Gyula Grosics", "birthdate":"1926-02-04", "club":"Deceased", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Hungary", "past_clubs":["Dorog", "Budapest Honvéd", "Tatabánya"]},
-  {"id":161, "name":"László Kubala", "birthdate":"1927-06-10", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Hungary/Spain", "past_clubs":["Ferencváros", "Vasas SC", "Pro Patria", "Barcelona", "Espanyol", "FC Zürich"]},
-  {"id":162, "name":"Robin van Persie", "birthdate":"1983-08-06", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["Feyenoord", "Arsenal", "Manchester United", "Fenerbahçe"]},
-  {"id":163, "name":"Arjen Robben", "birthdate":"1984-01-23", "club":"Retired", "league":"Sem liga", "position":"Winger", "nationality":"Netherlands", "past_clubs":["Groningen", "PSV", "Chelsea", "Real Madrid", "Bayern Munich"]},
-  {"id":164, "name":"Wesley Sneijder", "birthdate":"1984-06-09", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Ajax", "Real Madrid", "Inter Milan", "Galatasaray", "Nice", "Al-Gharafa"]},
-  {"id":165, "name":"Klaas-Jan Huntelaar", "birthdate":"1983-08-12", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["PSV", "De Graafschap", "AGOVV", "Heerenveen", "Ajax", "Real Madrid", "Milan", "Schalke 04"]},
-  {"id":166, "name":"Giovanni van Bronckhorst", "birthdate":"1975-02-05", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Netherlands", "past_clubs":["RKC Waalwijk", "Feyenoord", "Rangers", "Arsenal", "Barcelona"]},
-  {"id":167, "name":"Edwin van der Sar", "birthdate":"1970-10-29", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Netherlands", "past_clubs":["Ajax", "Juventus", "Fulham", "Manchester United"]},
-  {"id":168, "name":"Patrick Kluivert", "birthdate":"1976-07-01", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Netherlands", "past_clubs":["Ajax", "Milan", "Barcelona", "Newcastle United", "Valencia", "PSV", "Lille"]},
-  {"id":169, "name":"Frank de Boer", "birthdate":"1970-05-15", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Ajax", "Barcelona", "Galatasaray", "Rangers", "Al-Rayyan", "Al-Shamal"]},
-  {"id":170, "name":"Ronald de Boer", "birthdate":"1970-05-15", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Ajax", "Twente", "Barcelona", "Rangers", "Al-Rayyan", "Al-Shamal"]},
-  {"id":171, "name":"Jaap Stam", "birthdate":"1972-07-17", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Cambuur Leeuwarden", "Willem II", "PSV", "Manchester United", "Lazio", "Milan", "Ajax"]},
-  {"id":172, "name":"Rivellino", "birthdate":"1946-01-01", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Corinthians", "Fluminense", "Al-Hilal"]},
-  {"id":173, "name":"Carlos Alberto Torres", "birthdate":"1944-07-17", "club":"Deceased", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Fluminense", "Santos", "Botafogo", "Flamengo", "New York Cosmos"]},
-  {"id":174, "name":"Mário Zagallo", "birthdate":"1931-08-09", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["América", "Flamengo", "Botafogo"]},
-  {"id":175, "name":"Tostão", "birthdate":"1947-01-25", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["América Mineiro", "Cruzeiro"]},
-  {"id":176, "name":"Vavá", "birthdate":"1934-11-12", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Sport Recife", "Vasco da Gama", "Atlético Madrid", "Palmeiras", "América"]},
-  {"id":177, "name":"Juan Román Riquelme", "birthdate":"1978-06-24", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Argentinos Juniors", "Boca Juniors", "Barcelona", "Villarreal"]},
-  {"id":178, "name":"Omar Sívori", "birthdate":"1935-10-02", "club":"Deceased", "league":"Sem liga", "position":"Forward", "nationality":"Argentina/Italy", "past_clubs":["River Plate", "Juventus", "Napoli"]},
-  {"id":179, "name":"Diego Simeone", "birthdate":"1970-04-28", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Vélez Sársfield", "Pisa", "Sevilla", "Atlético Madrid", "Inter Milan", "Lazio", "Racing Club"]},
-
-  {"id":181, "name":"Mario Kempes", "birthdate":"1954-07-15", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["Instituto", "Rosario Central", "Valencia", "River Plate", "Hercules", "First Vienna", "St Pölten", "Kremser SC", "Fernández Vial", "Pelita Jaya"]},
-  {"id":182, "name":"Éric Abidal", "birthdate":"1979-09-11", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"France", "past_clubs":["Monaco", "Lille", "Lyon", "Barcelona", "Olympiacos"]},
-  {"id":183, "name":"Bixente Lizarazu", "birthdate":"1969-12-09", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"France", "past_clubs":["Bordeaux", "Athletic Bilbao", "Bayern Munich", "Marseille"]},
-  {"id":184, "name":"Emmanuel Petit", "birthdate":"1970-09-22", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Monaco", "Arsenal", "Barcelona", "Chelsea"]},
-  {"id":185, "name":"Youri Djorkaeff", "birthdate":"1968-03-09", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Grenoble", "Strasbourg", "Monaco", "Paris Saint-Germain", "Inter Milan", "Kaiserslautern", "Bolton", "Blackburn Rovers", "New York Red Bulls"]},
-  {"id":186, "name":"Robert Pirès", "birthdate":"1973-10-29", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Metz", "Marseille", "Arsenal", "Villarreal", "Aston Villa", "FC Goa"]},
-
-  {"id":188, "name":"Luis Figo", "birthdate":"1972-11-04", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Sporting CP", "Barcelona", "Real Madrid", "Inter Milan"]},
-  {"id":189, "name":"Mário Coluna", "birthdate":"1935-08-06", "club":"Deceased", "league":"Sem liga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica", "Lyon"]},
-  {"id":190, "name":"Paulo Futre", "birthdate":"1966-02-28", "club":"Retired", "league":"Sem liga", "position":"Winger", "nationality":"Portugal", "past_clubs":["Sporting CP", "Porto", "Atlético Madrid", "Benfica", "Marseille", "Reggiana", "Milan", "West Ham United", "Yokohama Flügels"]},
-  {"id":191, "name":"Vítor Baía", "birthdate":"1969-10-15", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Portugal", "past_clubs":["Porto", "Barcelona"]},
-  {"id":192, "name":"Fernando Couto", "birthdate":"1969-08-02", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Portugal", "past_clubs":["Porto", "Parma", "Barcelona", "Lazio"]},
-  {"id":193, "name":"Nuno Gomes", "birthdate":"1976-07-05", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Portugal", "past_clubs":["Boavista", "Benfica", "Fiorentina", "Braga", "Blackburn Rovers"]},
-  {"id":194, "name":"Emilio Butragueño", "birthdate":"1963-07-22", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Real Madrid", "Atlético Celaya"]},
-  {"id":195, "name":"Raúl", "birthdate":"1977-06-27", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Real Madrid", "Schalke 04", "Al Sadd", "New York Cosmos"]},
-  {"id":196, "name":"Fernando Hierro", "birthdate":"1968-03-23", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Spain", "past_clubs":["Real Valladolid", "Real Madrid", "Al Rayyan", "Bolton Wanderers"]},
-  {"id":197, "name":"Iker Casillas", "birthdate":"1981-05-20", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Spain", "past_clubs":["Real Madrid", "Porto"]},
-  {"id":198, "name":"Carles Puyol", "birthdate":"1978-04-13", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Spain", "past_clubs":["Barcelona"]},
-  {"id":199, "name":"David Villa", "birthdate":"1981-12-03", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Sporting Gijón", "Zaragoza", "Valencia", "Barcelona", "Atlético Madrid", "New York City", "Melbourne City", "Vissel Kobe"]},
-  {"id":200, "name":"Xavi", "birthdate":"1980-01-25", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Barcelona", "Al Sadd"]},
-  {"id":201, "name":"Andrés Iniesta", "birthdate":"1984-05-11", "club":"Emirates", "league":"UAE Pro League", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Barcelona", "Vissel Kobe"]},
-  {"id":202, "name":"Gianluigi Buffon", "birthdate":"1978-01-28", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Italy", "past_clubs":["Parma", "Juventus", "Paris Saint-Germain"]},
-  {"id":203, "name":"Ronaldinho", "birthdate":"1980-03-21", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Grêmio", "Paris Saint-Germain", "Barcelona", "Milan", "Flamengo", "Atlético Mineiro", "Querétaro", "Fluminense"]},
-
-  {"id":205, "name":"Wayne Rooney", "birthdate":"1985-10-24", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"England", "past_clubs":["Everton", "Manchester United", "DC United", "Derby County"]},
-  {"id":206, "name":"Rio Ferdinand", "birthdate":"1978-11-07", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"England", "past_clubs":["West Ham United", "Leeds United", "Manchester United", "Queens Park Rangers"]},
-  {"id":207, "name":"John Terry", "birthdate":"1980-12-07", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"England", "past_clubs":["Chelsea", "Aston Villa"]},
-  {"id":208, "name":"Gerard Piqué", "birthdate":"1987-02-02", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Spain", "past_clubs":["Manchester United", "Barcelona"]},
-  {"id":209, "name":"Andres Guardado", "birthdate":"1986-09-28", "club":"León", "league":"Liga MX", "position":"Midfielder", "nationality":"Mexico", "past_clubs":["Atlas", "Deportivo La Coruña", "Valencia", "Bayer Leverkusen", "PSV Eindhoven", "Real Betis"]},
-  {"id":210, "name":"Javier Hernández", "birthdate":"1988-06-01", "club":"Chivas", "league":"Liga MX", "position":"Forward", "nationality":"Mexico", "past_clubs":["Guadalajara", "Manchester United", "Real Madrid", "Bayer Leverkusen", "West Ham United", "Sevilla", "LA Galaxy"]},
-
-  {"id":212, "name":"Nemanja Vidić", "birthdate":"1981-10-21", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Serbia", "past_clubs":["Red Star Belgrade", "Spartak Moscow", "Manchester United", "Inter Milan"]},
-  {"id":213, "name":"Ashley Cole", "birthdate":"1980-12-20", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"England", "past_clubs":["Arsenal", "Chelsea", "Roma", "LA Galaxy", "Derby County"]},
-  {"id":214, "name":"Samuel Eto'o", "birthdate":"1981-03-10", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Cameroon", "past_clubs":["Real Madrid", "Mallorca", "Barcelona", "Inter Milan", "Anzhi Makhachkala", "Chelsea", "Everton", "Sampdoria", "Antalyaspor", "Konyaspor", "Qatar SC"]},
-  {"id":215, "name":"Didier Drogba", "birthdate":"1978-03-11", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Ivory Coast", "past_clubs":["Le Mans", "Guingamp", "Marseille", "Chelsea", "Shanghai Shenhua", "Galatasaray", "Montreal Impact", "Phoenix Rising"]},
-  {"id":216, "name":"David Beckham", "birthdate":"1975-05-02", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester United", "Preston North End", "Real Madrid", "LA Galaxy", "Milan", "Paris Saint-Germain"]},
-  {"id":217, "name":"Gareth Bale", "birthdate":"1989-07-16", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Wales", "past_clubs":["Southampton", "Tottenham Hotspur", "Real Madrid", "Los Angeles FC"]},
-  {"id":218, "name":"Javier Zanetti", "birthdate":"1973-08-10", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Argentina", "past_clubs":["Talleres", "Banfield", "Inter Milan"]},
-  {"id":219, "name":"Zlatan Ibrahimović", "birthdate":"1981-10-03", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Sweden", "past_clubs":["Malmö FF", "Ajax", "Juventus", "Inter Milan", "Barcelona", "Milan", "Paris Saint-Germain", "Manchester United", "LA Galaxy"]},
-  {"id":220, "name":"Ronaldo Nazário", "birthdate":"1976-09-18", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Cruzeiro", "PSV", "Barcelona", "Inter Milan", "Real Madrid", "Milan", "Corinthians"]},
-  {"id":221, "name":"Ronaldinho Gaúcho", "birthdate":"1980-03-21", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Grêmio", "Paris Saint-Germain", "Barcelona", "Milan", "Flamengo", "Atlético Mineiro", "Querétaro", "Fluminense"]},
-  {"id":222, "name":"Zinedine Zidane", "birthdate":"1972-06-23", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Cannes", "Bordeaux", "Juventus", "Real Madrid"]},
-  {"id":223, "name":"Luis Figo", "birthdate":"1972-11-04", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Sporting CP", "Barcelona", "Real Madrid", "Inter Milan"]},
-  {"id":224, "name":"Marcelo", "birthdate":"1988-05-12", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Fluminense", "Real Madrid", "Olympiacos"]},
-  {"id":225, "name":"Sergio Agüero", "birthdate":"1988-06-02", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["Independiente", "Atlético Madrid", "Manchester City", "Barcelona"]},
-  {"id":226, "name":"Nuno Mendes", "birthdate":"2002-06-19", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Defender", "nationality":"Portugal", "past_clubs":["Sporting CP"]},
-  {"id":227, "name":"Rúben Dias", "birthdate":"1997-05-14", "club":"Manchester City", "league":"Premier League", "position":"Defender", "nationality":"Portugal", "past_clubs":["Benfica"]},
-  {"id":228, "name":"Bernardo Silva", "birthdate":"1994-08-10", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica", "Monaco"]},
-  {"id":229, "name":"João Cancelo", "birthdate":"1994-05-27", "club":"Al-Hilal", "league":"Saudi Pro League", "position":"Defender", "nationality":"Portugal", "past_clubs":["Benfica", "Valencia", "Inter Milan", "Juventus", "Manchester City", "Bayern Munich", "Barcelona"]},
-  {"id":230, "name":"Rafael Leão", "birthdate":"1999-06-10", "club":"Milan", "league":"Serie A", "position":"Forward", "nationality":"Portugal", "past_clubs":["Sporting CP", "Lille"]},
-  {"id":231, "name":"Roberto Firmino", "birthdate":"1991-10-02", "club":"Al-Ahli", "league":"Saudi Pro League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Figueirense", "Hoffenheim", "Liverpool"]},
-
-  {"id":232, "name":"Philippe Coutinho", "birthdate":"1992-06-12", "club":"Al-Duhail", "league":"Qatar Stars League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Inter Milan", "Espanyol", "Liverpool", "Barcelona", "Bayern Munich", "Aston Villa"]},
-  {"id":233, "name":"Richarlison", "birthdate":"1997-05-10", "club":"Tottenham", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["América Mineiro", "Fluminense", "Watford", "Everton"]},
-  {"id":234, "name":"Alisson", "birthdate":"1992-10-02", "club":"Liverpool", "league":"Premier League", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Internacional", "Roma"]},
-  {"id":235, "name":"Gabriel Jesus", "birthdate":"1997-04-03", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Palmeiras", "Manchester City"]},
-  {"id":236, "name":"Vinícius Júnior", "birthdate":"2000-07-12", "club":"Real Madrid", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Flamengo"]},
-  {"id":237, "name":"Rodrygo", "birthdate":"2001-01-09", "club":"Real Madrid", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santos"]},
-  {"id":238, "name":"Éder Militão", "birthdate":"1998-01-18", "club":"Real Madrid", "league":"La Liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo", "Porto"]},
-  {"id":239, "name":"Casemiro", "birthdate":"1992-02-23", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["São Paulo", "Porto", "Real Madrid"]},
-  {"id":240, "name":"Sadio Mané", "birthdate":"1992-04-10", "club":"Al-Nassr", "league":"Saudi Pro League", "position":"Forward", "nationality":"Senegal", "past_clubs":["Metz", "Red Bull Salzburg", "Southampton", "Liverpool", "Bayern Munich"]},
-  {"id":241, "name":"Thibaut Courtois", "birthdate":"1992-05-11", "club":"Real Madrid", "league":"La Liga", "position":"Goalkeeper", "nationality":"Belgium", "past_clubs":["Genk", "Atlético Madrid", "Chelsea"]},
-  {"id":242, "name":"Dani Carvajal", "birthdate":"1992-01-11", "club":"Real Madrid", "league":"La Liga", "position":"Defender", "nationality":"Spain", "past_clubs":["Bayer Leverkusen"]},
-  {"id":243, "name":"Federico Valverde", "birthdate":"1998-07-22", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Peñarol", "Deportivo La Coruña"]},
-  {"id":244, "name":"Eduardo Camavinga", "birthdate":"2002-11-10", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Rennes"]},
-  {"id":245, "name":"Xabi Alonso", "birthdate":"1981-11-25", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Manager", "nationality":"Spain", "past_clubs":["Real Sociedad", "Liverpool", "Real Madrid", "Bayern Munich"]},
-  {"id":246, "name":"Kim Min-jae", "birthdate":"1996-11-15", "club":"Bayern Munich", "league":"Bundesliga", "position":"Defender", "nationality":"South Korea", "past_clubs":["Jeonbuk Hyundai Motors", "Beijing Guoan", "Fenerbahçe", "Napoli"]},
-  {"id":247, "name":"William Saliba", "birthdate":"2001-03-24", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Saint-Étienne", "Nice", "Marseille"]},
-  {"id":248, "name":"Bukayo Saka", "birthdate":"2001-09-05", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":[]},
-  {"id":249, "name":"Declan Rice", "birthdate":"1999-01-14", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Chelsea", "West Ham United"]},
-  {"id":250, "name":"Martin Ødegaard", "birthdate":"1998-12-17", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"Norway", "past_clubs":["Strømsgodset", "Real Madrid", "Heerenveen", "Vitesse", "Real Sociedad"]},
-  {"id":251, "name":"Thomas Partey", "birthdate":"1993-06-13", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"Ghana", "past_clubs":["Atlético Madrid", "Mallorca", "Almería"]},
-  {"id":252, "name":"Cole Palmer", "birthdate":"2002-05-06", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester City"]},
-  {"id":253, "name":"Enzo Fernández", "birthdate":"2001-01-17", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["River Plate", "Defensa y Justicia", "Benfica"]},
-  {"id":254, "name":"Moisés Caicedo", "birthdate":"2001-11-02", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"Ecuador", "past_clubs":["Independiente del Valle", "Brighton & Hove Albion"]},
-  {"id":255, "name":"Marc Cucurella", "birthdate":"1998-07-22", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"Spain", "past_clubs":["Barcelona", "Eibar", "Getafe", "Brighton & Hove Albion"]},
-  {"id":256, "name":"Reece James", "birthdate":"1999-12-08", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Wigan Athletic"]},
-  {"id":257, "name":"Marcus Rashford", "birthdate":"1997-10-31", "club":"Manchester United", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":[]},
-  {"id":258, "name":"Mason Mount", "birthdate":"1999-01-10", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Chelsea", "Vitesse", "Derby County"]},
-  {"id":259, "name":"Lisandro Martínez", "birthdate":"1998-01-18", "club":"Manchester United", "league":"Premier League", "position":"Defender", "nationality":"Argentina", "past_clubs":["Newell's Old Boys", "Defensa y Justicia", "Ajax"]},
-  {"id":260, "name":"Bruno Guimarães", "birthdate":"1997-11-16", "club":"Newcastle United", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Audax", "Athletico Paranaense", "Lyon"]},
-  {"id":261, "name":"Alexander Isak", "birthdate":"1999-09-21", "club":"Newcastle United", "league":"Premier League", "position":"Forward", "nationality":"Sweden", "past_clubs":["AIK", "Borussia Dortmund", "Willem II", "Real Sociedad"]},
-  {"id":262, "name":"Heung-min Son", "birthdate":"1992-07-08", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Forward", "nationality":"South Korea", "past_clubs":["Hamburger SV", "Bayer Leverkusen"]},
-  {"id":263, "name":"James Maddison", "birthdate":"1996-11-23", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Coventry City", "Norwich City", "Aberdeen", "Leicester City"]},
-  {"id":264, "name":"Cristian Romero", "birthdate":"1998-04-27", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Defender", "nationality":"Argentina", "past_clubs":["Belgrano", "Genoa", "Atalanta"]},
-  {"id":265, "name":"Alexis Mac Allister", "birthdate":"1998-12-24", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Argentinos Juniors", "Boca Juniors", "Brighton & Hove Albion"]},
-  {"id":266, "name":"Dominik Szoboszlai", "birthdate":"2000-10-25", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"Hungary", "past_clubs":["FC Liefering", "Red Bull Salzburg", "RB Leipzig"]},
-  {"id":267, "name":"Trent Alexander-Arnold", "birthdate":"1998-10-07", "club":"Liverpool", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":[]},
-  {"id":268, "name":"Andrew Robertson", "birthdate":"1994-03-11", "club":"Liverpool", "league":"Premier League", "position":"Defender", "nationality":"Scotland", "past_clubs":["Queen's Park", "Dundee United", "Hull City"]},
-  {"id":269, "name":"Jeremy Doku", "birthdate":"2002-05-27", "club":"Manchester City", "league":"Premier League", "position":"Forward", "nationality":"Belgium", "past_clubs":["Anderlecht", "Rennes"]},
-  {"id":270, "name":"Jack Grealish", "birthdate":"1995-09-10", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Aston Villa", "Notts County"]},
-  {"id":271, "name":"Josko Gvardiol", "birthdate":"2002-01-23", "club":"Manchester City", "league":"Premier League", "position":"Defender", "nationality":"Croatia", "past_clubs":["Dinamo Zagreb", "RB Leipzig"]},
-  {"id":272, "name":"Julian Alvarez", "birthdate":"2000-01-31", "club":"Atlético Madrid", "league":"La Liga", "position":"Forward", "nationality":"Argentina", "past_clubs":["River Plate", "Manchester City"]},
-  {"id":273, "name":"Mateo Kovacic", "birthdate":"1994-05-06", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Croatia", "past_clubs":["Dinamo Zagreb", "Inter Milan", "Real Madrid", "Chelsea"]},
-  {"id":274, "name":"Ilkay Gündogan", "birthdate":"1990-10-24", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bochum", "Nürnberg", "Borussia Dortmund", "Manchester City"]},
-  {"id":275, "name":"Pedri", "birthdate":"2002-11-25", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Las Palmas"]},
-  {"id":276, "name":"Gavi", "birthdate":"2004-08-05", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":[]},
-  {"id":277, "name":"Lamine Yamal", "birthdate":"2007-07-13", "club":"Barcelona", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":[]},
-  {"id":278, "name":"Jules Koundé", "birthdate":"1998-11-12", "club":"Barcelona", "league":"La Liga", "position":"Defender", "nationality":"France", "past_clubs":["Bordeaux", "Sevilla"]},
-  {"id":279, "name":"Frenkie de Jong", "birthdate":"1997-05-12", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Willem II", "Ajax"]},
-  {"id":280, "name":"Ferran Torres", "birthdate":"2000-02-29", "club":"Barcelona", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Valencia", "Manchester City"]},
-  {"id":281, "name":"Ansu Fati", "birthdate":"2002-10-31", "club":"Brighton & Hove Albion", "league":"Premier League", "position":"Forward", "nationality":"Spain", "past_clubs":["Barcelona"]},
-  {"id":282, "name":"David Alaba", "birthdate":"1992-06-24", "club":"Real Madrid", "league":"La Liga", "position":"Defender", "nationality":"Austria", "past_clubs":["Bayern Munich"]},
-  {"id":283, "name":"Antonio Rüdiger", "birthdate":"1993-03-03", "club":"Real Madrid", "league":"La Liga", "position":"Defender", "nationality":"Germany", "past_clubs":["Stuttgart", "Roma", "Chelsea"]},
-  {"id":284, "name":"Aurélien Tchouaméni", "birthdate":"2000-01-27", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"France", "past_clubs":["Bordeaux", "Monaco"]},
-  {"id":285, "name":"Alexander Sorloth", "birthdate":"1995-12-05", "club":"Atlético Madrid", "league":"La Liga", "position":"Forward", "nationality":"Norway", "past_clubs":["Rosenborg", "Bodø/Glimt", "Midtjylland", "Groningen", "Crystal Palace", "Gent", "Trabzonspor", "RB Leipzig", "Real Sociedad", "Villarreal"]},
-  {"id":286, "name":"Koke", "birthdate":"1992-01-08", "club":"Atlético Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":[]},
-  {"id":287, "name":"Antoine Griezmann", "birthdate":"1991-03-21", "club":"Atlético Madrid", "league":"La Liga", "position":"Forward", "nationality":"France", "past_clubs":["Real Sociedad", "Barcelona"]},
-  {"id":288, "name":"Marcos Llorente", "birthdate":"1995-01-30", "club":"Atlético Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Real Madrid"]},
-  {"id":289, "name":"Mikel Oyarzabal", "birthdate":"1997-04-21", "club":"Real Sociedad", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":[]},
-  {"id":290, "name":"Take Kubo", "birthdate":"2001-06-04", "club":"Real Sociedad", "league":"La Liga", "position":"Forward", "nationality":"Japan", "past_clubs":["FC Tokyo", "Yokohama F. Marinos", "Real Madrid", "Mallorca", "Villarreal", "Getafe"]},
-  {"id":291, "name":"Isco", "birthdate":"1992-04-21", "club":"Real Betis", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Valencia", "Málaga", "Real Madrid", "Sevilla"]},
-  {"id":292, "name":"Ayoze Pérez", "birthdate":"1993-07-29", "club":"Villarreal", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Tenerife", "Newcastle United", "Leicester City", "Real Betis"]},
-  {"id":293, "name":"Jadon Sancho", "birthdate":"2000-03-25", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":["Manchester City", "Borussia Dortmund", "Manchester United"]},
-  {"id":294, "name":"Marco Reus", "birthdate":"1989-05-31", "club":"Los Angeles Galaxy", "league":"MLS", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Rot Weiss Ahlen", "Borussia Mönchengladbach", "Borussia Dortmund"]},
-  {"id":295, "name":"Mats Hummels", "birthdate":"1988-12-16", "club":"Roma", "league":"Serie A", "position":"Defender", "nationality":"Germany", "past_clubs":["Bayern Munich", "Borussia Dortmund"]},
-  {"id":296, "name":"Jamal Musiala", "birthdate":"2003-02-26", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Chelsea"]},
-  {"id":297, "name":"Leroy Sané", "birthdate":"1996-01-11", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"Germany", "past_clubs":["Schalke 04", "Manchester City"]},
-  {"id":298, "name":"Alphonso Davies", "birthdate":"2000-11-02", "club":"Bayern Munich", "league":"Bundesliga", "position":"Defender", "nationality":"Canada", "past_clubs":["Vancouver Whitecaps"]},
-  {"id":299, "name":"Aleksandar Pavlovic", "birthdate":"2004-05-03", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":[]},
-  {"id":300, "name":"Léon Goretzka", "birthdate":"1995-02-06", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bochum", "Schalke 04"]},
-  {"id":301, "name":"Kingsley Coman", "birthdate":"1996-06-13", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"France", "past_clubs":["Paris Saint-Germain", "Juventus"]},
-  {"id":302, "name":"Serge Gnabry", "birthdate":"1995-07-14", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"Germany", "past_clubs":["Arsenal", "West Bromwich Albion", "Werder Bremen", "Hoffenheim"]},
-  {"id":303, "name":"Dayot Upamecano", "birthdate":"1998-10-27", "club":"Bayern Munich", "league":"Bundesliga", "position":"Defender", "nationality":"France", "past_clubs":["Red Bull Salzburg", "RB Leipzig"]},
-  {"id":304, "name":"Eric Maxim Choupo-Moting", "birthdate":"1989-03-23", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"Cameroon", "past_clubs":["Hamburg", "Nürnberg", "Mainz 05", "Schalke 04", "Stoke City", "Paris Saint-Germain"]},
-  {"id":305, "name":"Florian Wirtz", "birthdate":"2003-05-03", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Köln"]},
-  {"id":306, "name":"Matthijs de Ligt", "birthdate":"1999-08-12", "club":"Manchester United", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Ajax", "Juventus", "Bayern Munich"]},
-  {"id":307, "name":"Noussair Mazraoui", "birthdate":"1997-11-14", "club":"Bayern Munich", "league":"Bundesliga", "position":"Defender", "nationality":"Morocco", "past_clubs":["Ajax"]},
-  {"id":308, "name":"Michael Olise", "birthdate":"2001-12-12", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"France", "past_clubs":["Reading", "Crystal Palace"]},
-  {"id":309, "name":"Mathys Tel", "birthdate":"2005-04-27", "club":"Bayern Munich", "league":"Bundesliga", "position":"Forward", "nationality":"France", "past_clubs":["Rennes"]},
-  {"id":310, "name":"Benjamin Šeško", "birthdate":"2003-05-31", "club":"RB Leipzig", "league":"Bundesliga", "position":"Forward", "nationality":"Slovenia", "past_clubs":["Domzale", "Red Bull Salzburg"]},
-  {"id":311, "name":"Dani Olmo", "birthdate":"1998-05-07", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Espanyol", "Dinamo Zagreb", "RB Leipzig"]},
-  {"id":312, "name":"Loïs Openda", "birthdate":"2000-02-16", "club":"RB Leipzig", "league":"Bundesliga", "position":"Forward", "nationality":"Belgium", "past_clubs":["Standard Liège", "Club Brugge", "Vitesse", "Lens"]},
-  {"id":313, "name":"Christopher Nkunku", "birthdate":"1997-11-14", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"France", "past_clubs":["Paris Saint-Germain", "RB Leipzig"]},
-  {"id":314, "name":"Jonas Hofmann", "birthdate":"1992-07-14", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Hoffenheim", "Borussia Dortmund", "Borussia Mönchengladbach"]},
-  {"id":315, "name":"Robert Andrich", "birthdate":"1994-09-22", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Hertha BSC", "Dynamo Dresden", "Wehen Wiesbaden", "Heidenheim", "Union Berlin"]},
-  {"id":316, "name":"Alejandro Grimaldo", "birthdate":"1995-09-20", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Defender", "nationality":"Spain", "past_clubs":["Barcelona B", "Benfica"]},
-  {"id":317, "name":"Granit Xhaka", "birthdate":"1992-09-27", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Midfielder", "nationality":"Switzerland", "past_clubs":["Basel", "Borussia Mönchengladbach", "Arsenal"]},
-  {"id":318, "name":"Jeremie Frimpong", "birthdate":"2000-12-10", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Manchester City", "Celtic"]},
-  {"id":319, "name":"Victor Boniface", "birthdate":"2000-12-23", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Forward", "nationality":"Nigeria", "past_clubs":["Bodø/Glimt", "Union Saint-Gilloise"]},
-  {"id":320, "name":"Piero Hincapié", "birthdate":"2002-01-09", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Defender", "nationality":"Ecuador", "past_clubs":["Independiente del Valle", "Talleres"]},
-  {"id":321, "name":"Julian Brandt", "birthdate":"1996-05-02", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Wolfsburg", "Bayer Leverkusen"]},
-  {"id":322, "name":"Karim Adeyemi", "birthdate":"2002-01-18", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Forward", "nationality":"Germany", "past_clubs":["SpVgg Unterhaching", "Red Bull Salzburg"]},
-  {"id":323, "name":"Nico Schlotterbeck", "birthdate":"1999-12-01", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Defender", "nationality":"Germany", "past_clubs":["SC Freiburg", "Union Berlin"]},
-  {"id":324, "name":"Niklas Süle", "birthdate":"1995-09-03", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Defender", "nationality":"Germany", "past_clubs":["Hoffenheim", "Bayern Munich"]},
-  {"id":325, "name":"Marcel Sabitzer", "birthdate":"1994-03-17", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Midfielder", "nationality":"Austria", "past_clubs":["Admira Wacker", "Rapid Wien", "RB Leipzig", "Bayern Munich", "Manchester United"]},
-  {"id":326, "name":"Eden Hazard", "birthdate":"1991-01-07", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Belgium", "past_clubs":["Lille", "Chelsea", "Real Madrid"]},
-  {"id":327, "name":"Achraf Hakimi", "birthdate":"1998-11-04", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Defender", "nationality":"Morocco", "past_clubs":["Real Madrid", "Borussia Dortmund", "Inter Milan"]},
-  {"id":328, "name":"Warren Zaïre-Emery", "birthdate":"2006-03-08", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Midfielder", "nationality":"France", "past_clubs":[]},
-  {"id":329, "name":"Vitinha", "birthdate":"2000-02-13", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Porto", "Wolverhampton Wanderers"]},
-  {"id":330, "name":"Ousmane Dembélé", "birthdate":"1997-05-15", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Forward", "nationality":"France", "past_clubs":["Rennes", "Borussia Dortmund", "Barcelona"]},
-  {"id":331, "name":"Lucas Beraldo", "birthdate":"2003-11-24", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo"]},
-  {"id":332, "name":"Gianluigi Donnarumma", "birthdate":"1999-02-25", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Goalkeeper", "nationality":"Italy", "past_clubs":["Milan"]},
-  {"id":333, "name":"Willian", "birthdate":"1988-08-09", "club":"Fulham", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Corinthians", "Shakhtar Donetsk", "Anzhi Makhachkala", "Chelsea", "Arsenal"]},
-  {"id":334, "name":"Andreas Pereira", "birthdate":"1996-01-01", "club":"Fulham", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Manchester United", "Granada", "Valencia", "Lazio", "Flamengo"]},
-  {"id":335, "name":"João Victor", "birthdate":"1998-10-27", "club":"Vasco da Gama", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Corinthians", "Benfica", "Nantes"]},
-  {"id":336, "name":"Pedro", "birthdate":"1997-06-20", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Fluminense", "Fiorentina"]},
-  {"id":337, "name":"Douglas Luiz", "birthdate":"1998-05-09", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Manchester City", "Girona"]},
-  {"id":338, "name":"Gabriel Martinelli", "birthdate":"2001-06-18", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Ituano"]},
-  {"id":339, "name":"Antônio Carlos Júnior", "birthdate":"1993-03-07", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Corinthians", "Avaí", "Vitória", "Flamengo", "Palmeiras", "Orlando City"]},
-  {"id":340, "name":"Lucas Veríssimo", "birthdate":"1995-07-07", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Linense", "Ponte Preta", "Santos", "Benfica", "Al-Duhail"]},
-  {"id":341, "name":"Bruno Guimarães", "birthdate":"1997-11-16", "club":"Newcastle United", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Audax", "Athletico Paranaense", "Lyon"]},
-  {"id":342, "name":"Endrick", "birthdate":"2006-07-21", "club":"Real Madrid", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Palmeiras"]},
-  {"id":343, "name":"Aymeric Laporte", "birthdate":"1994-05-27", "club":"Al-Nassr", "league":"Saudi Pro League", "position":"Defender", "nationality":"Spain", "past_clubs":["Athletic Bilbao", "Manchester City"]},
-  {"id":344, "name":"Nacho Fernández", "birthdate":"1990-01-18", "club":"Al-Qadsiah", "league":"Saudi Pro League", "position":"Defender", "nationality":"Spain", "past_clubs":["Real Madrid"]},
-  {"id":345, "name":"Raphinha", "birthdate":"1996-12-14", "club":"Barcelona", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Vitória Guimarães", "Sporting CP", "Rennes", "Leeds United"]},
-  {"id":346, "name":"Darwin Núñez", "birthdate":"1999-06-24", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Peñarol", "Almería", "Benfica"]},
-  {"id":347, "name":"Ronald Araújo", "birthdate":"1999-03-07", "club":"Barcelona", "league":"La Liga", "position":"Defender", "nationality":"Uruguay", "past_clubs":["Rentistas", "Boston River", "Barcelona B"]},
-  {"id":348, "name":"Federico Valverde", "birthdate":"1998-07-22", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Peñarol", "Deportivo La Coruña"]},
-  {"id":349, "name":"Alejandro Garnacho", "birthdate":"2004-07-01", "club":"Manchester United", "league":"Premier League", "position":"Forward", "nationality":"Argentina", "past_clubs":["Atlético Madrid"]},
-  {"id":350, "name":"Enzo Fernández", "birthdate":"2001-01-17", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["River Plate", "Defensa y Justicia", "Benfica"]},
-  {"id":351, "name":"Pau Torres", "birthdate":"1997-01-16", "club":"Aston Villa", "league":"Premier League", "position":"Defender", "nationality":"Spain", "past_clubs":["Villarreal", "Málaga"]},
-  {"id":352, "name":"Emiliano Martínez", "birthdate":"1992-09-02", "club":"Aston Villa", "league":"Premier League", "position":"Goalkeeper", "nationality":"Argentina", "past_clubs":["Independiente", "Arsenal", "Oxford United", "Sheffield Wednesday", "Rotherham United", "Wolverhampton Wanderers", "Getafe", "Reading"]},
-  {"id":353, "name":"Marquinhos", "birthdate":"1994-05-14", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Defender", "nationality":"Brazil", "past_clubs":["Corinthians", "Roma"]},
-  {"id":354, "name":"Ollie Watkins", "birthdate":"1995-12-30", "club":"Aston Villa", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":["Exeter City", "Weston-super-Mare", "Brentford"]},
-  {"id":355, "name":"Kobbie Mainoo", "birthdate":"2005-04-19", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":[]},
-  {"id":356, "name":"Kieran Trippier", "birthdate":"1990-09-19", "club":"Newcastle United", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Manchester City", "Barnsley", "Burnley", "Tottenham Hotspur", "Atlético Madrid"]},
-  {"id":357, "name":"Anthony Gordon", "birthdate":"2001-02-24", "club":"Newcastle United", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":["Everton", "Preston North End"]},
-  {"id":358, "name":"Marc Guéhi", "birthdate":"2000-07-13", "club":"Crystal Palace", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Chelsea", "Swansea City"]},
-  {"id":359, "name":"Eberechi Eze", "birthdate":"1998-06-29", "club":"Crystal Palace", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Millwall", "Wycombe Wanderers", "Queens Park Rangers"]},
-  {"id":360, "name":"Morgan Gibbs-White", "birthdate":"2000-01-27", "club":"Nottingham Forest", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Wolverhampton Wanderers", "Swansea City", "Sheffield United"]},
-  {"id":361, "name":"Jean-Clair Todibo", "birthdate":"1999-12-30", "club":"West Ham United", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Toulouse", "Barcelona", "Schalke 04", "Benfica", "Nice"]},
-  {"id":362, "name":"Wesley Fofana", "birthdate":"2000-12-17", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Saint-Étienne", "Leicester City"]},
-  {"id":363, "name":"Matheus Cunha", "birthdate":"1999-05-27", "club":"Wolverhampton Wanderers", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Coritiba", "Sion", "RB Leipzig", "Hertha BSC", "Atlético Madrid"]},
-  {"id":364, "name":"Pedro Neto", "birthdate":"2000-03-09", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Portugal", "past_clubs":["Braga", "Lazio", "Wolverhampton Wanderers"]},
-  {"id":365, "name":"Kai Havertz", "birthdate":"1999-06-11", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"Germany", "past_clubs":["Bayer Leverkusen", "Chelsea"]},
-  {"id":366, "name":"Ben White", "birthdate":"1997-10-08", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Brighton & Hove Albion", "Newport County", "Peterborough United", "Leeds United"]},
-  {"id":367, "name":"Igor Jesus", "birthdate":"2001-02-12", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Coritiba", "Shabab Al-Ahli"]},
-  {"id":368, "name":"João Félix", "birthdate":"1999-11-10", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Portugal", "past_clubs":["Benfica", "Atlético Madrid", "Barcelona"]},
-  {"id":369, "name":"Raphaël Varane", "birthdate":"1993-04-25", "club":"Como", "league":"Serie A", "position":"Defender", "nationality":"France", "past_clubs":["Lens", "Real Madrid", "Manchester United"]},
-  {"id":370, "name":"Alessandro Bastoni", "birthdate":"1999-04-13", "club":"Inter Milan", "league":"Serie A", "position":"Defender", "nationality":"Italy", "past_clubs":["Atalanta", "Parma"]},
-  {"id":371, "name":"Hakan Çalhanoglu", "birthdate":"1994-02-08", "club":"Inter Milan", "league":"Serie A", "position":"Midfielder", "nationality":"Turkey", "past_clubs":["Karlsruher SC", "Hamburg", "Bayer Leverkusen", "Milan"]},
-  {"id":372, "name":"Lautaro Martínez", "birthdate":"1997-08-22", "club":"Inter Milan", "league":"Serie A", "position":"Forward", "nationality":"Argentina", "past_clubs":["Racing Club"]},
-  {"id":373, "name":"Dusan Vlahović", "birthdate":"2000-01-28", "club":"Juventus", "league":"Serie A", "position":"Forward", "nationality":"Serbia", "past_clubs":["Partizan", "Fiorentina"]},
-  {"id":374, "name":"Ademola Lookman", "birthdate":"1997-10-20", "club":"Atalanta", "league":"Serie A", "position":"Forward", "nationality":"Nigeria", "past_clubs":["Charlton Athletic", "Everton", "RB Leipzig", "Fulham", "Leicester City"]},
-  {"id":375, "name":"Riccardo Calafiori", "birthdate":"2002-05-19", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"Italy", "past_clubs":["Roma", "Genoa", "Basel", "Bologna"]},
-  {"id":376, "name":"Gabigol", "birthdate":"1996-08-30", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santos", "Inter Milan", "Benfica"]},
-  {"id":377, "name":"Giorgian De Arrascaeta", "birthdate":"1994-06-01", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Defensor Sporting", "Cruzeiro"]},
-  {"id":378, "name":"Everton Ribeiro", "birthdate":"1989-04-10", "club":"Bahia", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Corinthians", "São Caetano", "Coritiba", "Cruzeiro", "Flamengo"]},
-  {"id":379, "name":"Raphael Veiga", "birthdate":"1995-06-19", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Coritiba", "Atlético Paranaense"]},
-  {"id":380, "name":"Rony", "birthdate":"1995-05-11", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Remo", "Náutico", "Albirex Niigata", "Athletico Paranaense"]},
-  {"id":381, "name":"Weverton", "birthdate":"1987-12-13", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Corinthians", "Portuguesa", "Atlético Paranaense"]},
-  {"id":382, "name":"Gustavo Gómez", "birthdate":"1993-05-06", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Paraguay", "past_clubs":["Libertad", "Lanús", "Milan"]},
-  {"id":383, "name":"Giuliano Galoppo", "birthdate":"1999-06-18", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Banfield"]},
-  {"id":384, "name":"Luis Díaz", "birthdate":"1997-01-13", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Colombia", "past_clubs":["Atlético Junior", "Porto"]},
-  {"id":385, "name":"Darwin Núñez", "birthdate":"1999-06-24", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Peñarol", "Almería", "Benfica"]},
-  {"id":386, "name":"Walter Kannemann", "birthdate":"1991-03-14", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Argentina", "past_clubs":["San Lorenzo", "Atlas"]},
-  {"id":387, "name":"Villasanti", "birthdate":"1998-01-24", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Paraguay", "past_clubs":["Cerro Porteño", "Nacional"]},
-  {"id":388, "name":"Paulinho", "birthdate":"2000-07-15", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Bayer Leverkusen"]},
-  {"id":389, "name":"Hulk", "birthdate":"1986-07-25", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Vitória", "Kawasaki Frontale", "Consadóle Sapporo", "Tokyo Verdy", "Porto", "Zenit Saint Petersburg", "Shanghai SIPG"]},
-  {"id":390, "name":"Evanilson", "birthdate":"1999-10-06", "club":"Bournemouth", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Fluminense", "Porto"]},
-  {"id":391, "name":"Pedro", "birthdate":"1997-06-20", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Fluminense", "Fiorentina"]},
-  {"id":392, "name":"Gerson", "birthdate":"1997-05-20", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Fluminense", "Roma", "Fiorentina", "Marseille"]},
-  {"id":393, "name":"Adryelson", "birthdate":"1998-06-23", "club":"Lyon", "league":"Ligue 1", "position":"Defender", "nationality":"Brazil", "past_clubs":["Sport Recife", "Al-Wasl", "Botafogo"]},
-  {"id":394, "name":"Lucas Perri", "birthdate":"1997-12-10", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["São Paulo", "Crystal Palace", "Náutico"]},
-  {"id":395, "name":"Eduardo Vargas", "birthdate":"1989-11-20", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Chile", "past_clubs":["Cobreloa", "Universidad de Chile", "Napoli", "Grêmio", "Valencia", "Queens Park Rangers", "Hoffenheim", "Tigres UANL"]},
-  {"id":396, "name":"João Paulo", "birthdate":"1995-07-06", "club":"Santos", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Atlético GO", "Botão", "Atlético PR"]},
-  {"id":397, "name":"Valentim Germain", "birthdate":"2006-03-17", "club":"Lyon", "league":"Ligue 1", "position":"Forward", "nationality":"France", "past_clubs":[]},
-  {"id":398, "name":"Rayan Cherki", "birthdate":"2003-08-17", "club":"Lyon", "league":"Ligue 1", "position":"Midfielder", "nationality":"France", "past_clubs":[]},
-  {"id":399, "name":"Nemanja Matic", "birthdate":"1988-08-01", "club":"Lyon", "league":"Ligue 1", "position":"Midfielder", "nationality":"Serbia", "past_clubs":["Kolubara", "Kosice", "Vitesse", "Benfica", "Chelsea", "Manchester United", "Roma"]},
-  {"id":400, "name":"Marcos Leonardo", "birthdate":"2003-05-02", "club":"Benfica", "league":"Primeira Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santos"]},
-  {"id":401, "name":"Everton Cebolinha", "birthdate":"1996-03-22", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Grêmio", "Benfica"]},
-  {"id":402, "name":"Bruno Henrique", "birthdate":"1990-12-30", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Goias", "Wolfsburg", "Santos"]},
-  {"id":403, "name":"De La Cruz", "birthdate":"1997-06-01", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Liverpool FC (URU)", "River Plate"]},
-  {"id":404, "name":"Rogério Ceni", "birthdate":"1973-01-22", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Sinop", "São Paulo"]},
-  {"id":405, "name":"Cassão", "birthdate":"1992-06-16", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["PSV", "Sparta Rotterdam", "Flamengo", "Vitória", "Fluminense"]},
-  {"id":406, "name":"Fábio Santos", "birthdate":"1985-09-16", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo", "Cruzeiro", "Santos", "Monaco", "Grêmio", "Atlético Mineiro"]},
-
-  {"id":407, "name":"Fagner", "birthdate":"1989-06-11", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Corinthians", "PSV Eindhoven", "Vasco da Gama", "Wolfsburg", "Vitória"]},
-  {"id":408, "name":"Dudu", "birthdate":"1992-01-07", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Dynamo Kyiv", "Grêmio", "Al-Duhail"]},
-  {"id":409, "name":"Gabriel Menino", "birthdate":"2000-09-29", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":[]},
-  {"id":410, "name":"Beltran", "birthdate":"2001-04-28", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["River Plate"]},
-
-  {"id":412, "name":"Abel Ferreira", "birthdate":"1978-12-22", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Portugal", "past_clubs":["Sporting CP", "Braga", "PAOK"]},
-  {"id":413, "name":"Wellington Rato", "birthdate":"1992-03-19", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Atlético Goianiense", "Ferroviaria", "Ponte Preta", "CRB", "Sampaio Corrêa"]},
-  {"id":414, "name":"Luciano", "birthdate":"1993-05-18", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Corinthians", "Leganés", "Fluminense", "Parana", "Avaí", "Corinthians", "Grêmio"]},
-  {"id":415, "name":"Rafael", "birthdate":"1989-07-09", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Atlético Mineiro"]},
-  {"id":416, "name":"Marcos Rocha", "birthdate":"1988-12-11", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Atlético Mineiro", "Ponte Preta"]},
-  {"id":417, "name":"Zubeldía", "birthdate":"1981-04-13", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Argentina", "past_clubs":["Racing Club", "Internacional"]},
-  {"id":418, "name":"Germán Cano", "birthdate":"1988-01-02", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Argentina", "past_clubs":["Lanús", "Nacional", "Deportivo Pereira", "Pachuca", "Coloméx", "Chácaras", "Indep. Medellín", "Vasco da Gama"]},
-  {"id":419, "name":"Felipe Melo", "birthdate":"1983-06-26", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo", "Cruzeiro", "Grêmio", "Mallorca", "Racing Santander", "Almería", "Fiorentina", "Juventus", "Galatasaray", "Inter Milan", "Palmeiras"]},
-  {"id":420, "name":"Ganso", "birthdate":"1989-10-12", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Santos", "São Paulo", "Sevilla", "Amiens"]},
-  {"id":421, "name":"Keno", "birthdate":"1989-09-10", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santa Cruz", "Atlas", "Puebla", "Palmeiras", "Pyramids", "Atlético Mineiro"]},
-  {"id":422, "name":"Diniz", "birthdate":"1974-03-11", "club":"Cruzeiro", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Atlético Paranaense", "Guarani", "Santos", "Fluminense", "São Paulo"]},
-  {"id":423, "name":"Jhon Arías", "birthdate":"1997-09-21", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Colombia", "past_clubs":["América de Cali", "Patrícios", "Santa Fe", "Independiente"]},
-  {"id":424, "name":"André", "birthdate":"2001-07-16", "club":"Wolverhampton", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Fluminense"]},
-  {"id":425, "name":"Líma", "birthdate":"1999-12-18", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":[]},
-  {"id":426, "name":"Martinelli", "birthdate":"2001-07-25", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":[]},
-  {"id":427, "name":"Fábio", "birthdate":"1980-09-30", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Cruzeiro"]},
-  {"id":428, "name":"Renato Augusto", "birthdate":"1988-02-08", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo", "Bayer Leverkusen", "Corinthians", "Beijing Guoan"]},
-  {"id":429, "name":"Dida", "birthdate":"1973-10-07", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Vitória", "Cruzeiro", "Lugano", "Corinthians", "Milan", "Internacional", "Portuguesa", "Grêmio"]},
-  {"id":430, "name":"Jerome Boateng", "birthdate":"1988-09-03", "club":"LASK", "league":"Austrian Bundesliga", "position":"Defender", "nationality":"Germany", "past_clubs":["Hertha BSC", "Hamburger SV", "Manchester City", "Bayern Munich", "Lyon", "Salernitana"]},
-  {"id":431, "name":"Everton Ribeiro", "birthdate":"1989-04-10", "club":"Bahia", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Corinthians", "São Caetano", "Coritiba", "Cruzeiro", "Al-Ahli", "Flamengo"]},
-  {"id":432, "name":"Paulista", "birthdate":"1986-06-15", "club":"Vasco da Gama", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Ituano", "Santos", "Arsenal", "Villarreal"]},
-  {"id":433, "name":"Arrascaeta", "birthdate":"1994-06-01", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Defensor Sporting", "Cruzeiro"]},
-  {"id":434, "name":"Soteldo", "birthdate":"1997-06-28", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Venezuela", "past_clubs":["Zamora", "Huachipato", "Universidad de Chile", "Santos", "Toronto FC", "Tigres UANL"]},
-  {"id":435, "name":"Villasanti", "birthdate":"1998-06-05", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Paraguay", "past_clubs":["Cerro Porteno", "Guaraní"]},
-  {"id":436, "name":"Cristaldo", "birthdate":"1989-03-15", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Argentina", "past_clubs":["Vela", "Arsenal de Sarandí", "Metalist Kharkiv", "Bologna", "Palmeiras", "Cruz Azul", "Rayo Vallecano", "Boca Juniors", "Monterrey", "Huracán"]},
-  {"id":437, "name":"Renato Portaluppi", "birthdate":"1962-09-09", "club":"Grêmio", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Brazil", "past_clubs":["Fluminense", "Flamengo", "Athlético Paranaense"]},
-  {"id":438, "name":"Pepê", "birthdate":"1997-02-24", "club":"Porto", "league":"Primeira Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Foz do Iguaçu", "Grêmio"]},
-  {"id":439, "name":"Vitão", "birthdate":"1993-12-12", "club":"Internacional", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Palmeiras", "Botafogo", "Santos", "Atlético GO"]},
-  {"id":440, "name":"Alan Patrick", "birthdate":"1991-05-13", "club":"Internacional", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Santos", "Internacional", "Shakhtar Donetsk", "Flamengo", "Palmeiras"]},
-  {"id":441, "name":"Roger Machado", "birthdate":"1975-04-25", "club":"Internacional", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Brazil", "past_clubs":["Juventude", "Novo Hamburgo", "Grêmio", "Atlético Mineiro", "Palmeiras", "Bahia", "Fluminense", "Grêmio"]},
-  {"id":442, "name":"Wanderson", "birthdate":"1994-10-07", "club":"Internacional", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Belenenses", "Liefering", "Red Bull Salzburg", "LASK", "Krasnodar"]},
-  {"id":443, "name":"Arana", "birthdate":"1997-04-14", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Corinthians", "Sevilla", "Atalanta"]},
-  {"id":444, "name":"Deyverson", "birthdate":"1991-05-08", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Belenenses", "Köln", "Levante", "Alavés", "Palmeiras", "Getafe", "Cuiabá"]},
-  {"id":445, "name":"Gabriel", "birthdate":"1992-11-18", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo", "Internacional", "Palmeiras"]},
-  {"id":446, "name":"Tiquinho Soares", "birthdate":"1991-01-17", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Nacional-MG", "Sousa EC", "America-RN", "Bot-PB", "Oeste", "Nacional", "Vitória de Guimarães", "Porto", "Tianjin Teda", "Guangzhou", "Olympiacos"]},
-  {"id":447, "name":"Artur Jorge", "birthdate":"1972-02-17", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Portugal", "past_clubs":["Braga"]},
-  {"id":448, "name":"Marlon Freitas", "birthdate":"1995-05-19", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Fluminense", "Ceará", "Boavista", "Criciúma", "Boa", "Atlético Goianiense"]},
-  {"id":449, "name":"John", "birthdate":"1996-03-12", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Internacional", "Santos"]},
-  {"id":450, "name":"Cuiabano", "birthdate":"2000-05-14", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Grêmio"]},
-  {"id":451, "name":"Igor Jesus", "birthdate":"2001-02-02", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Shabab Al-Ahli"]},
-  {"id":452, "name":"Rafael", "birthdate":"1990-07-09", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Manchester United", "Lyon", "Istanbul Basaksehir"]},
-  {"id":453, "name":"Jefferson", "birthdate":"1983-01-02", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Botafogo", "Trabzonspor"]},
-  {"id":454, "name":"Luiz Henrique", "birthdate":"2001-01-14", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Fluminense", "Real Betis"]},
-  {"id":455, "name":"Alexandre Pato", "birthdate":"1989-09-02", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Internacional", "Milan", "Corinthians", "São Paulo", "Chelsea", "Villarreal", "Tianjin Tianhai", "Orlando City"]},
-  {"id":456, "name":"Luiz Adriano", "birthdate":"1987-04-12", "club":"Internacional", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Internacional", "Shakhtar Donetsk", "Milan", "Spartak Moscow", "Palmeiras", "Antalyaspor"]},
-  {"id":457, "name":"Nino", "birthdate":"1997-04-10", "club":"Zenit", "league":"Russian Premier League", "position":"Defender", "nationality":"Brazil", "past_clubs":["Criciúma", "Fluminense"]},
-  {"id":458, "name":"Caio Paulista", "birthdate":"1998-06-09", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Avai", "Fluminense", "São Paulo"]},
-  {"id":459, "name":"Igor Coronado", "birthdate":"1992-08-03", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Milton Keynes Dons", "Banbury United", "Leatherhead", "Chesham United", "Green Harefield", "Floriana", "Trapani", "Palermo", "Al-Sharjah", "Al-Ittihad"]},
-  {"id":460, "name":"William", "birthdate":"1995-05-03", "club":"Cruzeiro", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Internacional", "Wolfsburg", "Schalke 04"]},
-  {"id":461, "name":"Alex Telles", "birthdate":"1992-12-15", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Juventude", "Grêmio", "Galatasaray", "Inter Milan", "Porto", "Manchester United", "Sevilla", "Al-Nassr"]},
-  {"id":462, "name":"Zé Rafael", "birthdate":"1993-06-16", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Coritiba", "Figueirense", "Bahia"]},
-  {"id":463, "name":"Richard Ríos", "birthdate":"2000-03-14", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Colombia", "past_clubs":["Guarani"]},
-  {"id":464, "name":"Pérez", "birthdate":"1996-03-01", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Newell's Old Boys"]},
-  {"id":465, "name":"Barboza", "birthdate":"1995-12-29", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Argentina", "past_clubs":["Defensa y Justicia", "Indep. del Valle", "River Plate", "Rosario Central", "Atlético MG"]},
-  {"id":466, "name":"Luiz Araújo", "birthdate":"1996-06-02", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["São Paulo", "Novorizontino", "Mirassol", "Lille", "Atlanta United"]},
-  {"id":467, "name":"Wesley", "birthdate":"2000-03-06", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Palmeiras"]},
-  {"id":468, "name":"Yuri Alberto", "birthdate":"2001-03-18", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Santos", "Internacional", "Zenit"]},
-  {"id":469, "name":"Matheuzinho", "birthdate":"2000-09-18", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Londrina", "Flamengo"]},
-  {"id":470, "name":"Raniele", "birthdate":"1996-09-18", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Avai", "Botafogo-SP", "Cuiabá"]},
-  {"id":471, "name":"Rômulo", "birthdate":"1995-12-02", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Novorizontino", "Avaí", "Ferroviaria", "Cruzeiro"]},
-  {"id":472, "name":"Veiga", "birthdate":"1995-06-29", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Santos", "Coritiba", "Athlético Paranaense"]},
-  {"id":473, "name":"Piquerez", "birthdate":"1998-08-24", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Uruguay", "past_clubs":["Defensor Sporting", "Peñarol", "Montevideo Wanderers"]},
-  {"id":474, "name":"Murilo", "birthdate":"1997-03-27", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Lokomotiv Moscow"]},
-  {"id":475, "name":"Dorival Júnior", "birthdate":"1962-04-25", "club":"Brazil", "league":"Seleção", "position":"Manager", "nationality":"Brazil", "past_clubs":["Cerezo Osaka", "Athlético Paranaense", "Flamengo", "Santos", "São Paulo", "Internacional", "Vasco", "Fluminense", "Palmeiras", "Atlético MG", "Coritiba"]},
-  {"id":476, "name":"Luis Guilherme", "birthdate":"2006-04-07", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":[]},
-  {"id":477, "name":"Gabriel Menino", "birthdate":"2000-09-29", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":[]},
-  {"id":478, "name":"Ayrton Lucas", "birthdate":"1997-06-19", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Fluminense", "Spartak Moscow"]},
-  {"id":479, "name":"Gerson", "birthdate":"1997-05-20", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Fluminense", "Roma", "Fiorentina", "Marseille"]},
-  {"id":480, "name":"Fabrizio Peralta", "birthdate":"2000-12-10", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Paraguay", "past_clubs":["Cerro Porteño"]},
-  {"id":481, "name":"Varela", "birthdate":"1993-03-24", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Uruguay", "past_clubs":["Peñarol", "Manchester United", "Real Madrid Castilla", "Eintracht Frankfurt", "Copenhagen"]},
-  {"id":482, "name":"Carlinhos", "birthdate":"1996-08-28", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["Nova Iguaçu", "Santos", "Defensa Y Justicia", "Botafogo-SP", "América RN", "Guarani", "Standard Liège"]},
-  {"id":483, "name":"Filipe Luís", "birthdate":"1985-08-09", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Figueirense", "Ajax", "Real Madrid B", "Deportivo La Coruña", "Atlético Madrid", "Chelsea", "Flamengo"]},
-  {"id":484, "name":"Tite", "birthdate":"1961-05-25", "club":"Flamengo", "league":"Brasileirão Série A", "position":"Manager", "nationality":"Brazil", "past_clubs":["Brazil", "Grêmio", "Corinthians", "Atlético MG", "Palmeiras", "Al Ain", "Al-Wahda", "Internacional"]},
-  {"id":485, "name":"Wellington", "birthdate":"1991-01-28", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Internacional", "Vasco", "Ponte Preta", "Chapecoense", "Athletico-PR", "Miami FC", "Fluminense", "Grêmio", "Japan"]},
-  {"id":486, "name":"Calleri", "birthdate":"1993-09-23", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Argentina", "past_clubs":["All Boys", "Boca Juniors", "West Ham", "Las Palmas", "Alavés", "Espanyol", "Osasuna"]},
-  {"id":487, "name":"Alisson", "birthdate":"1993-06-06", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Grêmio", "Al-Jazira"]},
-  {"id":488, "name":"Lucas Moura", "birthdate":"1992-08-13", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["São Paulo", "Paris Saint-Germain", "Tottenham"]},
-  {"id":489, "name":"Rafaíça", "birthdate":"1985-09-29", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Juventude", "Schalke 04", "Bayern Munich", "Flamengo", "Grêmio"]},
-  {"id":490, "name":"Michel Araújo", "birthdate":"1996-12-13", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Londrina", "Avai", "Fluminense"]},
-  {"id":491, "name":"Jandrei", "birthdate":"1993-03-01", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Atlético Tubarão", "Chapecoense", "Genoa", "Santos"]},
-  {"id":492, "name":"Richard Rios", "birthdate":"2000-04-02", "club":"Palmeiras", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Colombia", "past_clubs":["Flamengo", "Guarani"]},
-  {"id":493, "name":"Juan", "birthdate":"1979-02-01", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Flamengo", "Bayer Leverkusen", "Roma", "Internacional"]},
-  {"id":494, "name":"Diego Alves", "birthdate":"1985-06-24", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Atlético Mineiro", "Almería", "Valencia", "Flamengo"]},
-  {"id":495, "name":"Diego Cavalieri", "birthdate":"1982-12-01", "club":"Retired", "league":"Sem liga", "position":"Goalkeeper", "nationality":"Brazil", "past_clubs":["Palmeiras", "Liverpool", "Cesena", "Fluminense", "Crystal Palace", "Botafogo"]},
-  {"id":496, "name":"Jardine", "birthdate":"1974-01-17", "club":"Brazil Olympic", "league":"Seleção", "position":"Manager", "nationality":"Brazil", "past_clubs":["São Paulo"]},
-  {"id":497, "name":"Teixeira", "birthdate":"1990-01-05", "club":"Botafogo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Shakhtar Donetsk", "Jiangsu Suning"]},
-  {"id":498, "name":"Diego Ribas", "birthdate":"1985-02-28", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Santos", "Porto", "Werder Bremen", "Juventus", "Wolfsburg", "Atlético Madrid", "Fenerbahçe", "Flamengo"]},
-  {"id":499, "name":"Pedri", "birthdate":"2002-11-25", "club":"Barcelona", "league":"La Liga", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Las Palmas"]},
-  {"id":500, "name":"David De Gea", "birthdate":"1990-11-07", "club":"Fiorentina", "league":"Serie A", "position":"Goalkeeper", "nationality":"Spain", "past_clubs":["Atlético Madrid", "Manchester United"]},
-  {"id":501, "name":"Marc-André ter Stegen", "birthdate":"1992-04-30", "club":"Barcelona", "league":"La Liga", "position":"Goalkeeper", "nationality":"Germany", "past_clubs":["Borussia Mönchengladbach"]},
-  {"id":502, "name":"Mike Maignan", "birthdate":"1995-07-03", "club":"Milan", "league":"Serie A", "position":"Goalkeeper", "nationality":"France", "past_clubs":["Paris Saint-Germain", "Lille"]},
-  {"id":503, "name":"Diogo Leite", "birthdate":"1999-01-23", "club":"Union Berlin", "league":"Bundesliga", "position":"Defender", "nationality":"Portugal", "past_clubs":["Porto", "Braga"]},
-  {"id":504, "name":"Keylor Navas", "birthdate":"1986-12-15", "club":"Villarreal", "league":"La Liga", "position":"Goalkeeper", "nationality":"Costa Rica", "past_clubs":["Saprissa", "Albacete", "Levante", "Real Madrid", "Paris Saint-Germain", "Nottingham Forest"]},
-  {"id":505, "name":"Gianluigi Donnarumma", "birthdate":"1999-02-25", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Goalkeeper", "nationality":"Italy", "past_clubs":["Milan"]},
-  {"id":506, "name":"Diogo Costa", "birthdate":"1999-09-19", "club":"Porto", "league":"Primeira Liga", "position":"Goalkeeper", "nationality":"Portugal", "past_clubs":[]},
-  {"id":507, "name":"André Onana", "birthdate":"1996-04-02", "club":"Manchester United", "league":"Premier League", "position":"Goalkeeper", "nationality":"Cameroon", "past_clubs":["Barcelona B", "Ajax", "Inter Milan"]},
-  {"id":508, "name":"Yassine Bounou", "birthdate":"1991-04-05", "club":"Al-Hilal", "league":"Saudi Pro League", "position":"Goalkeeper", "nationality":"Morocco", "past_clubs":["Wydad Casablanca", "Atlético Madrid", "Zaragoza", "Girona", "Sevilla"]},
-  {"id":509, "name":"Emiliano Martínez", "birthdate":"1992-09-02", "club":"Aston Villa", "league":"Premier League", "position":"Goalkeeper", "nationality":"Argentina", "past_clubs":["Arsenal", "Oxford United", "Sheffield Wednesday", "Rotherham United", "Wolverhampton Wanderers", "Getafe", "Reading"]},
-  {"id":510, "name":"David Raya", "birthdate":"1995-09-15", "club":"Arsenal", "league":"Premier League", "position":"Goalkeeper", "nationality":"Spain", "past_clubs":["Blackburn Rovers", "Brentford"]},
-  {"id":511, "name":"Jordan Pickford", "birthdate":"1994-03-07", "club":"Everton", "league":"Premier League", "position":"Goalkeeper", "nationality":"England", "past_clubs":["Sunderland", "Darlington", "Burton Albion", "Carlisle United", "Bradford City", "Preston North End"]},
-  {"id":512, "name":"João Pedro", "birthdate":"2001-09-26", "club":"Brighton & Hove Albion", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Fluminense", "Watford"]},
-  {"id":513, "name":"Estêvão Willian", "birthdate":"2007-04-24", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Palmeiras"]},
-  {"id":514, "name":"Savinho", "birthdate":"2004-04-01", "club":"Manchester City", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Atlético Mineiro", "PSV Eindhoven", "Troyes", "Girona"]},
-  {"id":515, "name":"Yan Couto", "birthdate":"2002-06-03", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Coritiba", "Manchester City", "Girona", "Braga"]},
-  {"id":516, "name":"Nico Williams", "birthdate":"2002-07-12", "club":"Athletic Bilbao", "league":"La Liga", "position":"Forward", "nationality":"Spain", "past_clubs":[]},
-  {"id":517, "name":"João Neves", "birthdate":"2004-09-27", "club":"Paris Saint-Germain", "league":"Ligue 1", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica"]},
-  {"id":518, "name":"Antonio Nusa", "birthdate":"2005-04-17", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Forward", "nationality":"Norway", "past_clubs":["Stabæk", "Club Brugge"]},
-  {"id":519, "name":"Khvicha Kvaratskhelia", "birthdate":"2001-02-12", "club":"Napoli", "league":"Serie A", "position":"Forward", "nationality":"Georgia", "past_clubs":["Dinamo Tbilisi", "Rustavi", "Lokomotiv Moscow", "Rubin Kazan", "Dinamo Batumi"]},
-  {"id":520, "name":"Xavi Simons", "birthdate":"2003-04-21", "club":"RB Leipzig", "league":"Bundesliga", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Barcelona", "Paris Saint-Germain", "PSV Eindhoven"]},
-  {"id":521, "name":"Adam Hlozek", "birthdate":"2002-07-25", "club":"Bayer Leverkusen", "league":"Bundesliga", "position":"Forward", "nationality":"Czech Republic", "past_clubs":["Sparta Prague"]},
-  {"id":522, "name":"Kepa Arrizabalaga", "birthdate":"1994-10-03", "club":"Real Madrid", "league":"La Liga", "position":"Goalkeeper", "nationality":"Spain", "past_clubs":["Athletic Bilbao", "Chelsea", "Napoli"]},
-  {"id":523, "name":"Unai Simón", "birthdate":"1997-06-11", "club":"Athletic Bilbao", "league":"La Liga", "position":"Goalkeeper", "nationality":"Spain", "past_clubs":["Basconia", "Bilbao Athletic"]},
-  {"id":524, "name":"Leandro Trossard", "birthdate":"1994-12-04", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"Belgium", "past_clubs":["Genk", "Lommel", "Brighton & Hove Albion"]},
-  {"id":525, "name":"William Saliba", "birthdate":"2001-03-24", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Saint-Étienne", "Nice", "Marseille"]},
-  {"id":526, "name":"Declan Rice", "birthdate":"1999-01-14", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Chelsea", "West Ham United"]},
-  {"id":527, "name":"Emile Smith Rowe", "birthdate":"2000-07-28", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["RB Leipzig", "Huddersfield Town"]},
-  {"id":528, "name":"Kai Havertz", "birthdate":"1999-06-11", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Bayer Leverkusen", "Chelsea"]},
-  {"id":529, "name":"Mikel Merino", "birthdate":"1996-06-22", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"Spain", "past_clubs":["Osasuna", "Borussia Dortmund", "Newcastle United", "Real Sociedad"]},
-  {"id":530, "name":"Douglas Luiz", "birthdate":"1998-05-09", "club":"Juventus", "league":"Serie A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Vasco da Gama", "Manchester City", "Girona", "Aston Villa"]},
-  {"id":531, "name":"Oleksandr Zinchenko", "birthdate":"1996-12-15", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"Ukraine", "past_clubs":["Shakhtar Donetsk", "Manchester City"]},
-  {"id":532, "name":"Gabriel Martinelli", "birthdate":"2001-06-18", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Ituano"]},
-  {"id":533, "name":"Jurrien Timber", "birthdate":"2001-06-17", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Ajax"]},
-  {"id":534, "name":"Riccardo Calafiori", "birthdate":"2002-05-19", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"Italy", "past_clubs":["Roma", "Basel", "Bologna"]},
-  {"id":535, "name":"Benjamin White", "birthdate":"1997-10-08", "club":"Arsenal", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Brighton & Hove Albion", "Leeds United", "Peterborough United", "Newport County"]},
-  {"id":536, "name":"Bukayo Saka", "birthdate":"2001-09-05", "club":"Arsenal", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":[]},
-  {"id":537, "name":"Cole Palmer", "birthdate":"2002-05-06", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Manchester City"]},
-  {"id":538, "name":"Romeo Lavia", "birthdate":"2004-01-06", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"Belgium", "past_clubs":["Anderlecht", "Manchester City", "Southampton"]},
-  {"id":539, "name":"Mykhailo Mudryk", "birthdate":"2001-01-05", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Ukraine", "past_clubs":["Metalist Kharkiv", "Dnipro-1", "Shakhtar Donetsk"]},
-  {"id":540, "name":"Nicolas Jackson", "birthdate":"2001-06-20", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Senegal", "past_clubs":["Casa Sports", "Villarreal"]},
-  {"id":541, "name":"Pedro Neto", "birthdate":"2000-03-09", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"Portugal", "past_clubs":["Braga", "Lazio", "Wolverhampton Wanderers"]},
-  {"id":542, "name":"Christopher Nkunku", "birthdate":"1997-11-14", "club":"Chelsea", "league":"Premier League", "position":"Forward", "nationality":"France", "past_clubs":["Paris Saint-Germain", "RB Leipzig"]},
-  {"id":543, "name":"João Gomes", "birthdate":"2001-02-20", "club":"Wolverhampton Wanderers", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo"]},
-  {"id":544, "name":"Matheus Cunha", "birthdate":"1999-05-27", "club":"Wolverhampton Wanderers", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Coritiba", "Sion", "RB Leipzig", "Hertha BSC", "Atlético Madrid"]},
-  {"id":545, "name":"Sepp van den Berg", "birthdate":"2001-12-20", "club":"Brentford", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["PEC Zwolle", "Liverpool", "Preston North End", "Schalke 04", "Mainz 05"]},
-  {"id":546, "name":"Kiernan Dewsbury-Hall", "birthdate":"1998-09-06", "club":"Chelsea", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Leicester City", "Blackpool", "Luton Town"]},
-  {"id":547, "name":"Destiny Udogie", "birthdate":"2002-11-28", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Defender", "nationality":"Italy", "past_clubs":["Hellas Verona", "Udinese"]},
-  {"id":548, "name":"Miguel Almirón", "birthdate":"1994-02-10", "club":"Newcastle United", "league":"Premier League", "position":"Midfielder", "nationality":"Paraguay", "past_clubs":["Cerro Porteño", "Lanús", "Atlanta United"]},
-  {"id":549, "name":"Oscar Bobb", "birthdate":"2003-07-12", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Norway", "past_clubs":["Valerenga"]},
-  {"id":550, "name":"Kevin De Bruyne", "birthdate":"1991-06-28", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Belgium", "past_clubs":["Genk", "Chelsea", "Werder Bremen", "Wolfsburg"]},
-  {"id":551, "name":"Erling Haaland", "birthdate":"2000-07-21", "club":"Manchester City", "league":"Premier League", "position":"Forward", "nationality":"Norway", "past_clubs":["Bryne", "Molde", "Red Bull Salzburg", "Borussia Dortmund"]},
-  {"id":552, "name":"Phil Foden", "birthdate":"2000-05-28", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":[]},
-  {"id":553, "name":"Bernardo Silva", "birthdate":"1994-08-10", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica", "Monaco"]},
-  {"id":554, "name":"Mateo Kovacic", "birthdate":"1994-05-06", "club":"Manchester City", "league":"Premier League", "position":"Midfielder", "nationality":"Croatia", "past_clubs":["Dinamo Zagreb", "Inter Milan", "Real Madrid", "Chelsea"]},
-  {"id":555, "name":"Jean-Clair Todibo", "birthdate":"1999-12-30", "club":"West Ham United", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Toulouse", "Barcelona", "Schalke 04", "Benfica", "Nice"]},
-  {"id":556, "name":"Bruno Fernandes", "birthdate":"1994-09-08", "club":"Manchester United", "league":"Premier League", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Novara", "Udinese", "Sampdoria", "Sporting CP"]},
-  {"id":557, "name":"Reece James", "birthdate":"1999-12-08", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"England", "past_clubs":["Wigan Athletic"]},
-  {"id":558, "name":"Wesley Fofana", "birthdate":"2000-12-17", "club":"Chelsea", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Saint-Étienne", "Leicester City"]},
-  {"id":559, "name":"Federico Chiesa", "birthdate":"1997-10-25", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Italy", "past_clubs":["Fiorentina", "Juventus"]},
-  {"id":560, "name":"Ryan Gravenberch", "birthdate":"2002-05-16", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["Ajax", "Bayern Munich"]},
-  {"id":561, "name":"Dominik Szoboszlai", "birthdate":"2000-10-25", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"Hungary", "past_clubs":["FC Liefering", "Red Bull Salzburg", "RB Leipzig"]},
-  {"id":562, "name":"Alexis Mac Allister", "birthdate":"1998-12-24", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Argentinos Juniors", "Boca Juniors", "Brighton & Hove Albion"]},
-  {"id":563, "name":"Ibrahima Konaté", "birthdate":"1999-05-25", "club":"Liverpool", "league":"Premier League", "position":"Defender", "nationality":"France", "past_clubs":["Sochaux", "RB Leipzig"]},
-  {"id":564, "name":"Dejan Kulusevski", "birthdate":"2000-04-25", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Forward", "nationality":"Sweden", "past_clubs":["Brommapojkarna", "Atalanta", "Parma", "Juventus"]},
-  {"id":565, "name":"Morgan Gibbs-White", "birthdate":"2000-01-27", "club":"Nottingham Forest", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Wolverhampton Wanderers", "Swansea City", "Sheffield United"]},
-  {"id":566, "name":"Rasmus Højlund", "birthdate":"2003-02-04", "club":"Manchester United", "league":"Premier League", "position":"Forward", "nationality":"Denmark", "past_clubs":["FC Copenhagen", "Sturm Graz", "Atalanta"]},
-  {"id":567, "name":"Gustavo Scarpa", "birthdate":"1994-01-05", "club":"Atlético Mineiro", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Desportivo Brasil", "Red Bull Brasil", "Fluminense", "Palmeiras", "Nottingham Forest", "Olympiacos"]},
-  {"id":568, "name":"Alisson Euler", "birthdate":"1993-06-19", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Cruzeiro", "Internacional", "Grêmio", "Atlético Mineiro", "Al-Hazem"]},
-  {"id":569, "name":"Lucas Moura", "birthdate":"1992-08-13", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Brazil", "past_clubs":["São Paulo", "Paris Saint-Germain", "Tottenham Hotspur"]},
-  {"id":570, "name":"Alan Franco", "birthdate":"1997-02-11", "club":"São Paulo", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Argentina", "past_clubs":["Independiente", "Atlético Mineiro", "Atlanta United"]},
-  {"id":571, "name":"Luis Díaz", "birthdate":"1997-01-13", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Colombia", "past_clubs":["Atlético Junior", "Barranquilla FC", "Porto"]},
-  {"id":572, "name":"Diogo Jota", "birthdate":"1996-12-04", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Portugal", "past_clubs":["Paços de Ferreira", "Atlético Madrid", "Porto", "Wolverhampton Wanderers"]},
-  {"id":573, "name":"Mohamed Salah", "birthdate":"1992-06-15", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Egypt", "past_clubs":["Al Mokawloon", "Basel", "Chelsea", "Fiorentina", "Roma"]},
-  {"id":574, "name":"Virgil van Dijk", "birthdate":"1991-07-08", "club":"Liverpool", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Groningen", "Celtic", "Southampton"]},
-  {"id":575, "name":"Harvey Elliott", "birthdate":"2003-04-04", "club":"Liverpool", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Fulham", "Blackburn Rovers"]},
-  {"id":576, "name":"Cody Gakpo", "birthdate":"1999-05-07", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Netherlands", "past_clubs":["PSV Eindhoven"]},
-  {"id":577, "name":"Darwin Núñez", "birthdate":"1999-06-24", "club":"Liverpool", "league":"Premier League", "position":"Forward", "nationality":"Uruguay", "past_clubs":["Peñarol", "Almería", "Benfica"]},
-  {"id":578, "name":"James Maddison", "birthdate":"1996-11-23", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Coventry City", "Norwich City", "Leicester City"]},
-  {"id":579, "name":"Son Heung-min", "birthdate":"1992-07-08", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Forward", "nationality":"South Korea", "past_clubs":["Hamburger SV", "Bayer Leverkusen"]},
-  {"id":580, "name":"Manor Solomon", "birthdate":"1999-07-24", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Forward", "nationality":"Israel", "past_clubs":["Maccabi Petah Tikva", "Shakhtar Donetsk", "Fulham"]},
-  {"id":581, "name":"Yves Bissouma", "birthdate":"1996-08-30", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Midfielder", "nationality":"Mali", "past_clubs":["Lille", "Brighton & Hove Albion"]},
-  {"id":582, "name":"Cristian Romero", "birthdate":"1998-04-27", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Defender", "nationality":"Argentina", "past_clubs":["Belgrano", "Genoa", "Atalanta"]},
-  {"id":583, "name":"Brennan Johnson", "birthdate":"2001-05-23", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Forward", "nationality":"Wales", "past_clubs":["Nottingham Forest", "Lincoln City"]},
-  {"id":584, "name":"Pape Matar Sarr", "birthdate":"2002-09-14", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Midfielder", "nationality":"Senegal", "past_clubs":["Génération Foot", "Metz"]},
-  {"id":585, "name":"Rodrigo Bentancur", "birthdate":"1997-06-25", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Midfielder", "nationality":"Uruguay", "past_clubs":["Boca Juniors", "Juventus"]},
-  {"id":586, "name":"Micky van de Ven", "birthdate":"2001-04-19", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Volendam", "Wolfsburg"]},
-  {"id":587, "name":"Guglielmo Vicario", "birthdate":"1996-10-07", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Goalkeeper", "nationality":"Italy", "past_clubs":["Udinese", "Venezia", "Perugia", "Cagliari", "Empoli"]},
-  {"id":588, "name":"Radu Dragusin", "birthdate":"2002-02-03", "club":"Tottenham Hotspur", "league":"Premier League", "position":"Defender", "nationality":"Romania", "past_clubs":["Juventus", "Sampdoria", "Salernitana", "Genoa"]},
-  {"id":589, "name":"Jhon Durán", "birthdate":"2003-12-13", "club":"Aston Villa", "league":"Premier League", "position":"Forward", "nationality":"Colombia", "past_clubs":["Envigado", "Chicago Fire"]},
-  {"id":590, "name":"Jacob Ramsey", "birthdate":"2001-05-28", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":[]},
-  {"id":591, "name":"Emiliano Buendía", "birthdate":"1996-12-25", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Getafe", "Cultural Leonesa", "Norwich City"]},
-  {"id":592, "name":"Leon Bailey", "birthdate":"1997-08-09", "club":"Aston Villa", "league":"Premier League", "position":"Forward", "nationality":"Jamaica", "past_clubs":["AS Trencin", "Genk", "Bayer Leverkusen"]},
-  {"id":593, "name":"Amadou Onana", "birthdate":"2001-08-16", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"Belgium", "past_clubs":["Hoffenheim", "Hamburg", "Lille", "Everton"]},
-  {"id":594, "name":"Ross Barkley", "birthdate":"1993-12-05", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"England", "past_clubs":["Everton", "Chelsea", "Aston Villa", "Nice", "Luton Town"]},
-  {"id":595, "name":"Ollie Watkins", "birthdate":"1995-12-30", "club":"Aston Villa", "league":"Premier League", "position":"Forward", "nationality":"England", "past_clubs":["Exeter City", "Brentford"]},
-  {"id":596, "name":"Moussa Diaby", "birthdate":"1999-07-07", "club":"Al-Ittihad", "league":"Saudi Pro League", "position":"Forward", "nationality":"France", "past_clubs":["Paris Saint-Germain", "Crotone", "Bayer Leverkusen", "Aston Villa"]},
-  {"id":597, "name":"Youri Tielemans", "birthdate":"1997-05-07", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"Belgium", "past_clubs":["Anderlecht", "Monaco", "Leicester City"]},
-  {"id":598, "name":"Enzo Barrenechea", "birthdate":"2001-05-11", "club":"Aston Villa", "league":"Premier League", "position":"Midfielder", "nationality":"Argentina", "past_clubs":["Newell's Old Boys", "Sion", "Juventus", "Frosinone"]},
-  {"id":599, "name":"Ian Maatsen", "birthdate":"2002-03-10", "club":"Aston Villa", "league":"Premier League", "position":"Defender", "nationality":"Netherlands", "past_clubs":["Chelsea", "Charlton Athletic", "Coventry City", "Burnley", "Borussia Dortmund"]},
-  {"id":600, "name":"Samuel Omorodion", "birthdate":"2004-04-23", "club":"Porto", "league":"Primeira Liga", "position":"Forward", "nationality":"Spain", "past_clubs":["Granada", "Atlético Madrid", "Alavés"]},
-  {"id":601, "name":"Brian Brobbey", "birthdate":"2002-02-01", "club":"Ajax", "league":"Eredivisie", "position":"Forward", "nationality":"Netherlands", "past_clubs":["RB Leipzig"]},
-  {"id":602, "name":"Kenneth Taylor", "birthdate":"2002-05-16", "club":"Ajax", "league":"Eredivisie", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":[]},
-  {"id":603, "name":"Carlos Forbs", "birthdate":"2004-02-23", "club":"Ajax", "league":"Eredivisie", "position":"Forward", "nationality":"Portugal", "past_clubs":["Manchester City"]},
-  {"id":604, "name":"Daniele Rugani", "birthdate":"1994-07-29", "club":"Ajax", "league":"Eredivisie", "position":"Defender", "nationality":"Italy", "past_clubs":["Empoli", "Juventus", "Rennes", "Cagliari"]},
-  {"id":605, "name":"Josip Sutalo", "birthdate":"2000-02-28", "club":"Ajax", "league":"Eredivisie", "position":"Defender", "nationality":"Croatia", "past_clubs":["Dinamo Zagreb", "Istra 1961"]},
-  {"id":606, "name":"Jordan Henderson", "birthdate":"1990-06-17", "club":"Ajax", "league":"Eredivisie", "position":"Midfielder", "nationality":"England", "past_clubs":["Sunderland", "Coventry City", "Liverpool", "Al-Ettifaq"]},
-  {"id":607, "name":"Arda Güler", "birthdate":"2005-02-25", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Turkey", "past_clubs":["Genclerbirligi", "Fenerbahçe"]},
-  {"id":608, "name":"Endrick", "birthdate":"2006-07-21", "club":"Real Madrid", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Palmeiras"]},
-  {"id":609, "name":"Éder Militão", "birthdate":"1998-01-18", "club":"Real Madrid", "league":"La Liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["São Paulo", "Porto"]},
-  {"id":610, "name":"Raphinha", "birthdate":"1996-12-14", "club":"Barcelona", "league":"La Liga", "position":"Forward", "nationality":"Brazil", "past_clubs":["Avaí", "Vitória Sport Clube", "Sporting CP", "Rennes", "Leeds United"]},
-  {"id":611, "name":"Lucas Paquetá", "birthdate":"1997-08-27", "club":"West Ham United", "league":"Premier League", "position":"Midfielder", "nationality":"Brazil", "past_clubs":["Flamengo", "Lyon"]},
-  {"id":612, "name":"Joao Palhinha", "birthdate":"1995-07-09", "club":"Bayern Munich", "league":"Bundesliga", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Sporting CP", "Belenenses", "Moreirense", "Braga", "Fulham"]},
-  {"id":613, "name":"Francisco Conceicao", "birthdate":"2002-12-14", "club":"Porto", "league":"Primeira Liga", "position":"Forward", "nationality":"Portugal", "past_clubs":["Sporting CP", "Ajax"]},
-  {"id":614, "name":"André Gomes", "birthdate":"1993-07-30", "club":"Lille", "league":"Ligue 1", "position":"Midfielder", "nationality":"Portugal", "past_clubs":["Benfica", "Valencia", "Barcelona", "Everton"]},
-  {"id":615, "name":"James Rodríguez", "birthdate":"1991-07-12", "club":"Club León", "league":"Liga MX", "position":"Midfielder", "nationality":"Colombia", "past_clubs":["Envigado", "Banfield", "Porto", "Monaco", "Real Madrid", "Bayern Munich", "Everton", "Al-Rayyan", "Olympiacos", "São Paulo", "Rayo Vallecano"]},
-  {"id":616, "name":"Amin Younes", "birthdate":"1993-08-06", "club":"Free Agent", "league":"Sem liga", "position":"Midfielder", "nationality":"Germany", "past_clubs":["Borussia Mönchengladbach", "Kaiserslautern", "Ajax", "Napoli", "Eintracht Frankfurt", "Al-Ettifaq", "Utrecht"]},
-  {"id":617, "name":"Memphis Depay", "birthdate":"1994-02-13", "club":"Corinthians", "league":"Brasileirão Série A", "position":"Forward", "nationality":"Netherlands", "past_clubs":["PSV Eindhoven", "Manchester United", "Lyon", "Barcelona", "Atlético Madrid"]},
-  {"id":618, "name":"Jamie Bynoe-Gittens", "birthdate":"2004-08-08", "club":"Borussia Dortmund", "league":"Bundesliga", "position":"Forward", "nationality":"England", "past_clubs":["Manchester City"]},
-  {"id":619, "name":"Vanderson", "birthdate":"2001-06-21", "club":"Monaco", "league":"Ligue 1", "position":"Defender", "nationality":"Brazil", "past_clubs":["Grêmio"]},
-  {"id":620, "name":"Thilo Kehrer", "birthdate":"1996-09-21", "club":"Monaco", "league":"Ligue 1", "position":"Defender", "nationality":"Germany", "past_clubs":["Schalke 04", "Paris Saint-Germain", "West Ham United"]},
-  {"id":621, "name":"Folarin Balogun", "birthdate":"2001-07-03", "club":"Monaco", "league":"Ligue 1", "position":"Forward", "nationality":"United States", "past_clubs":["Arsenal", "Middlesbrough", "Reims"]},
-  {"id":622, "name":"Denis Zakaria", "birthdate":"1996-11-20", "club":"Monaco", "league":"Ligue 1", "position":"Midfielder", "nationality":"Switzerland", "past_clubs":["Servette", "Young Boys", "Borussia Mönchengladbach", "Juventus", "Chelsea"]},
-  {"id":623, "name":"Breel Embolo", "birthdate":"1997-02-14", "club":"Monaco", "league":"Ligue 1", "position":"Forward", "nationality":"Switzerland", "past_clubs":["Basel", "Schalke 04", "Borussia Mönchengladbach"]},
-  {"id":624, "name":"Youssouf Fofana", "birthdate":"1999-01-10", "club":"Milan", "league":"Serie A", "position":"Midfielder", "nationality":"France", "past_clubs":["Strasbourg", "Monaco"]},
-  {"id":625, "name":"Willian", "birthdate":"1988-08-09", "club":"Fulham", "league":"Premier League", "position":"Forward", "nationality":"Brazil", "past_clubs":["Corinthians", "Shakhtar Donetsk", "Anzhi Makhachkala", "Chelsea", "Arsenal"]},
-  {"id":626, "name":"Thiago Silva", "birthdate":"1984-09-22", "club":"Fluminense", "league":"Brasileirão Série A", "position":"Defender", "nationality":"Brazil", "past_clubs":["RS Futebol", "Juventude", "Fluminense", "Milan", "Paris Saint-Germain", "Chelsea"]},
-  {"id":627, "name":"Marcelo", "birthdate":"1988-05-12", "club":"Retired", "league":"Sem liga", "position":"Defender", "nationality":"Brazil", "past_clubs":["Fluminense", "Real Madrid", "Olympiacos"]},
-  {"id":628, "name":"Brahim Díaz", "birthdate":"1999-08-03", "club":"Real Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"Morocco", "past_clubs":["Manchester City", "Milan"]},
-  {"id":629, "name":"Rafael Leão", "birthdate":"1999-06-10", "club":"Milan", "league":"Serie A", "position":"Forward", "nationality":"Portugal", "past_clubs":["Sporting CP", "Lille"]},
-  {"id":630, "name":"Christian Pulisic", "birthdate":"1998-09-18", "club":"Milan", "league":"Serie A", "position":"Forward", "nationality":"United States", "past_clubs":["Borussia Dortmund", "Chelsea"]},
-  {"id":631, "name":"Timothy Weah", "birthdate":"2000-02-22", "club":"Juventus", "league":"Serie A", "position":"Forward", "nationality":"United States", "past_clubs":["Paris Saint-Germain", "Celtic", "Lille"]},
-  {"id":632, "name":"Ruben Loftus-Cheek", "birthdate":"1996-01-23", "club":"Milan", "league":"Serie A", "position":"Midfielder", "nationality":"England", "past_clubs":["Chelsea", "Crystal Palace", "Fulham"]},
-  {"id":633, "name":"Davide Calabria", "birthdate":"1996-12-06", "club":"Milan", "league":"Serie A", "position":"Defender", "nationality":"Italy", "past_clubs":[]},
-  {"id":634, "name":"Matteo Gabbia", "birthdate":"1999-10-21", "club":"Milan", "league":"Serie A", "position":"Defender", "nationality":"Italy", "past_clubs":["Lucchese", "Villarreal"]},
-  {"id":635, "name":"Tammy Abraham", "birthdate":"1997-10-02", "club":"Milan", "league":"Serie A", "position":"Forward", "nationality":"England", "past_clubs":["Chelsea", "Bristol City", "Swansea City", "Aston Villa", "Roma"]},
-  {"id":636, "name":"Olivier Giroud", "birthdate":"1986-09-30", "club":"Los Angeles FC", "league":"MLS", "position":"Forward", "nationality":"France", "past_clubs":["Grenoble", "Istres", "Tours", "Montpellier", "Arsenal", "Chelsea", "Milan"]},
-  {"id":637, "name":"Zlatan Ibrahimovic", "birthdate":"1981-10-03", "club":"Retired", "league":"Sem liga", "position":"Forward", "nationality":"Sweden", "past_clubs":["Malmö FF", "Ajax", "Juventus", "Inter Milan", "Barcelona", "Milan", "Paris Saint-Germain", "Manchester United", "LA Galaxy"]},
-  {"id":638, "name":"Tijjani Reijnders", "birthdate":"1998-07-28", "club":"Milan", "league":"Serie A", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["PEC Zwolle", "AZ Alkmaar"]},
-  {"id":639, "name":"Nicolò Barella", "birthdate":"1997-02-07", "club":"Inter Milan", "league":"Serie A", "position":"Midfielder", "nationality":"Italy", "past_clubs":["Cagliari"]},
-  {"id":640, "name":"Mehdi Taremi", "birthdate":"1992-07-18", "club":"Inter Milan", "league":"Serie A", "position":"Forward", "nationality":"Iran", "past_clubs":["Iranjavan", "Persepolis", "Al-Gharafa", "Rio Ave", "Porto"]},
-  {"id":641, "name":"Benjamin Pavard", "birthdate":"1996-03-28", "club":"Inter Milan", "league":"Serie A", "position":"Defender", "nationality":"France", "past_clubs":["Lille", "Stuttgart", "Bayern Munich"]},
-  {"id":642, "name":"Marcus Thuram", "birthdate":"1997-08-06", "club":"Inter Milan", "league":"Serie A", "position":"Forward", "nationality":"France", "past_clubs":["Sochaux", "Guingamp", "Borussia Mönchengladbach"]},
-  {"id":643, "name":"Giovanni Di Lorenzo", "birthdate":"1993-08-04", "club":"Napoli", "league":"Serie A", "position":"Defender", "nationality":"Italy", "past_clubs":["Lucchese", "Matera", "Reggina", "Empoli"]},
-  {"id":644, "name":"Romelu Lukaku", "birthdate":"1993-05-13", "club":"Napoli", "league":"Serie A", "position":"Forward", "nationality":"Belgium", "past_clubs":["Anderlecht", "Chelsea", "West Bromwich Albion", "Everton", "Manchester United", "Inter Milan", "Roma"]},
-  {"id":645, "name":"Scott McTominay", "birthdate":"1996-12-08", "club":"Napoli", "league":"Serie A", "position":"Midfielder", "nationality":"Scotland", "past_clubs":["Manchester United"]},
-  {"id":646, "name":"David Neres", "birthdate":"1997-03-03", "club":"Napoli", "league":"Serie A", "position":"Forward", "nationality":"Brazil", "past_clubs":["São Paulo", "Ajax", "Shakhtar Donetsk", "Benfica"]},
-  {"id":647, "name":"Alessandro Buongiorno", "birthdate":"1999-06-06", "club":"Napoli", "league":"Serie A", "position":"Defender", "nationality":"Italy", "past_clubs":["Torino", "Carpi", "Trapani"]},
-  {"id":648, "name":"Paulo Dybala", "birthdate":"1993-11-15", "club":"Roma", "league":"Serie A", "position":"Forward", "nationality":"Argentina", "past_clubs":["Instituto", "Palermo", "Juventus"]},
-  {"id":649, "name":"Matias Soulé", "birthdate":"2003-04-15", "club":"Roma", "league":"Serie A", "position":"Forward", "nationality":"Argentina", "past_clubs":["Vélez Sarsfield", "Juventus", "Frosinone"]},
-  {"id":650, "name":"Artem Dovbyk", "birthdate":"1997-06-21", "club":"Roma", "league":"Serie A", "position":"Forward", "nationality":"Ukraine", "past_clubs":["Cherkaskyi Dnipro", "Dnipro-1", "Midtjylland", "SønderjyskE", "Girona"]},
-  {"id":651, "name":"Kevin-Prince Boateng", "birthdate":"1987-03-06", "club":"Retired", "league":"Sem liga", "position":"Midfielder", "nationality":"Ghana", "past_clubs":["Hertha BSC", "Tottenham Hotspur", "Borussia Dortmund", "Portsmouth", "Milan", "Schalke 04", "Las Palmas", "Eintracht Frankfurt", "Sassuolo", "Barcelona", "Fiorentina", "Beşiktaş", "Monza", "Hertha BSC"]},
-  {"id":652, "name":"Martin Odegaard", "birthdate":"1998-12-17", "club":"Arsenal", "league":"Premier League", "position":"Midfielder", "nationality":"Norway", "past_clubs":["Strømsgodset", "Real Madrid", "Heerenveen", "Vitesse", "Real Sociedad"]},
-  {"id":653, "name":"Conor Gallagher", "birthdate":"2000-02-06", "club":"Atlético Madrid", "league":"La Liga", "position":"Midfielder", "nationality":"England", "past_clubs":["Chelsea", "Charlton Athletic", "Swansea City", "West Bromwich Albion", "Crystal Palace"]},
-  {"id":654, "name":"Gleison Bremer", "birthdate":"1997-03-18", "club":"Juventus", "league":"Serie A", "position":"Defender", "nationality":"Brazil", "past_clubs":["Desportivo Brasil", "São Paulo", "Atlético Mineiro", "Torino"]},
-  {"id":655, "name":"Teun Koopmeiners", "birthdate":"1998-02-28", "club":"Juventus", "league":"Serie A", "position":"Midfielder", "nationality":"Netherlands", "past_clubs":["AZ Alkmaar", "Atalanta"]}
+  {
+    "id": 1,
+    "name": "Lionel Messi",
+    "birthdate": "1987-06-24",
+    "club": "Inter Miami",
+    "league": "MLS",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Barcelona",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Cristiano Ronaldo",
+    "birthdate": "1985-02-05",
+    "club": "Al Nassr",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Manchester United",
+      "Real Madrid",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 3,
+    "name": "Neymar Jr",
+    "birthdate": "1992-02-05",
+    "club": "Al Hilal",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Barcelona",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 4,
+    "name": "Kylian Mbappé",
+    "birthdate": "1998-12-20",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Monaco"
+    ]
+  },
+  {
+    "id": 5,
+    "name": "Erling Haaland",
+    "birthdate": "2000-07-21",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Bryne",
+      "Molde",
+      "Red Bull Salzburg",
+      "Borussia Dortmund"
+    ]
+  },
+  {
+    "id": 6,
+    "name": "Kevin De Bruyne",
+    "birthdate": "1991-06-28",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Genk",
+      "Chelsea",
+      "Werder Bremen",
+      "Wolfsburg"
+    ]
+  },
+  {
+    "id": 7,
+    "name": "Karim Benzema",
+    "birthdate": "1987-12-19",
+    "club": "Al-Ittihad",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Lyon",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 8,
+    "name": "Luka Modric",
+    "birthdate": "1985-09-09",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Croatia",
+    "past_clubs": [
+      "Dinamo Zagreb",
+      "Tottenham"
+    ]
+  },
+  {
+    "id": 9,
+    "name": "Robert Lewandowski",
+    "birthdate": "1988-08-21",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Poland",
+    "past_clubs": [
+      "Znicz Pruszków",
+      "Lech Poznań",
+      "Borussia Dortmund",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 10,
+    "name": "Vinícius Júnior",
+    "birthdate": "2000-07-12",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Winger",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 11,
+    "name": "Mohamed Salah",
+    "birthdate": "1992-06-15",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Egypt",
+    "past_clubs": [
+      "El Mokawloon",
+      "Basel",
+      "Chelsea",
+      "Fiorentina",
+      "Roma"
+    ]
+  },
+  {
+    "id": 12,
+    "name": "Harry Kane",
+    "birthdate": "1993-07-28",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Tottenham",
+      "Leyton Orient",
+      "Millwall",
+      "Norwich City",
+      "Leicester City"
+    ]
+  },
+  {
+    "id": 13,
+    "name": "Jude Bellingham",
+    "birthdate": "2003-06-29",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Birmingham City",
+      "Borussia Dortmund"
+    ]
+  },
+  {
+    "id": 14,
+    "name": "Rodri",
+    "birthdate": "1996-06-22",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Villarreal",
+      "Atlético Madrid"
+    ]
+  },
+  {
+    "id": 15,
+    "name": "Bruno Fernandes",
+    "birthdate": "1994-09-08",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Novara",
+      "Udinese",
+      "Sampdoria",
+      "Sporting CP"
+    ]
+  },
+  {
+    "id": 16,
+    "name": "Virgil van Dijk",
+    "birthdate": "1991-07-08",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Groningen",
+      "Celtic",
+      "Southampton"
+    ]
+  },
+  {
+    "id": 17,
+    "name": "Joshua Kimmich",
+    "birthdate": "1995-02-08",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 18,
+    "name": "Son Heung-min",
+    "birthdate": "1992-07-08",
+    "club": "Tottenham",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "South Korea",
+    "past_clubs": [
+      "Hamburg",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 19,
+    "name": "Pedri",
+    "birthdate": "2002-11-25",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Las Palmas"
+    ]
+  },
+  {
+    "id": 20,
+    "name": "Phil Foden",
+    "birthdate": "2000-05-28",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 21,
+    "name": "Sergio Busquets",
+    "birthdate": "1988-07-16",
+    "club": "Inter Miami",
+    "league": "MLS",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 22,
+    "name": "Jordi Alba",
+    "birthdate": "1989-03-21",
+    "club": "Inter Miami",
+    "league": "MLS",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Valencia",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 23,
+    "name": "Casemiro",
+    "birthdate": "1992-02-23",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Real Madrid",
+      "Porto"
+    ]
+  },
+  {
+    "id": 24,
+    "name": "Ederson",
+    "birthdate": "1993-08-17",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Rio Ave",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 25,
+    "name": "Alisson Becker",
+    "birthdate": "1992-10-02",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Roma"
+    ]
+  },
+  {
+    "id": 26,
+    "name": "Manuel Neuer",
+    "birthdate": "1986-03-27",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Goalkeeper",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Schalke 04"
+    ]
+  },
+  {
+    "id": 27,
+    "name": "Jan Oblak",
+    "birthdate": "1993-01-07",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Goalkeeper",
+    "nationality": "Slovenia",
+    "past_clubs": [
+      "Olimpija Ljubljana",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 28,
+    "name": "Giorgio Chiellini",
+    "birthdate": "1984-08-14",
+    "club": "LAFC",
+    "league": "MLS",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Livorno",
+      "Fiorentina",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 29,
+    "name": "Leonardo Bonucci",
+    "birthdate": "1987-05-01",
+    "club": "Fenerbahçe",
+    "league": "Süper Lig",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Inter Milan",
+      "Pisa",
+      "Genoa",
+      "Bari",
+      "Juventus",
+      "Milan",
+      "Union Berlin"
+    ]
+  },
+  {
+    "id": 30,
+    "name": "Keylor Navas",
+    "birthdate": "1986-12-15",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Goalkeeper",
+    "nationality": "Costa Rica",
+    "past_clubs": [
+      "Saprissa",
+      "Albacete",
+      "Levante",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 31,
+    "name": "Raphaël Varane",
+    "birthdate": "1993-04-25",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Lens",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 32,
+    "name": "Pepe",
+    "birthdate": "1983-02-26",
+    "club": "Porto",
+    "league": "Primeira Liga",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Marítimo",
+      "Porto",
+      "Real Madrid",
+      "Beşiktaş"
+    ]
+  },
+  {
+    "id": 33,
+    "name": "Reece James",
+    "birthdate": "1999-12-08",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Wigan Athletic"
+    ]
+  },
+  {
+    "id": 34,
+    "name": "David Luiz",
+    "birthdate": "1987-04-22",
+    "club": "Flamengo",
+    "league": "Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vitória",
+      "Benfica",
+      "Chelsea",
+      "Paris Saint-Germain",
+      "Arsenal"
+    ]
+  },
+  {
+    "id": 35,
+    "name": "Fernandinho",
+    "birthdate": "1985-05-04",
+    "club": "Athletico Paranaense",
+    "league": "Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Paranaense",
+      "Shakhtar Donetsk",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 36,
+    "name": "Paul Pogba",
+    "birthdate": "1993-03-15",
+    "club": "Free Agent",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Manchester United",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 37,
+    "name": "N'Golo Kanté",
+    "birthdate": "1991-03-29",
+    "club": "Al Ittihad",
+    "league": "Saudi Pro League",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Boulogne",
+      "Caen",
+      "Leicester City",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 38,
+    "name": "Toni Kroos",
+    "birthdate": "1990-01-04",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 39,
+    "name": "Ivan Rakitić",
+    "birthdate": "1988-03-10",
+    "club": "Sevilla",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Croatia",
+    "past_clubs": [
+      "Basel",
+      "Schalke 04",
+      "Sevilla",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 40,
+    "name": "Ander Herrera",
+    "birthdate": "1989-08-14",
+    "club": "Athletic Bilbao",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Zaragoza",
+      "Athletic Bilbao",
+      "Manchester United",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 41,
+    "name": "Ángel Di María",
+    "birthdate": "1988-02-14",
+    "club": "Benfica",
+    "league": "Primeira Liga",
+    "position": "Winger",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Rosario Central",
+      "Benfica",
+      "Real Madrid",
+      "Manchester United",
+      "Paris Saint-Germain",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 42,
+    "name": "Pierre-Emerick Aubameyang",
+    "birthdate": "1989-06-18",
+    "club": "Marseille",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "Gabon",
+    "past_clubs": [
+      "Milan",
+      "Saint-Étienne",
+      "Borussia Dortmund",
+      "Arsenal",
+      "Barcelona",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 43,
+    "name": "Radamel Falcao",
+    "birthdate": "1986-02-10",
+    "club": "Rayo Vallecano",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "River Plate",
+      "Porto",
+      "Atlético Madrid",
+      "Monaco",
+      "Manchester United",
+      "Chelsea",
+      "Galatasaray"
+    ]
+  },
+  {
+    "id": 44,
+    "name": "Edinson Cavani",
+    "birthdate": "1987-02-14",
+    "club": "Boca Juniors",
+    "league": "Primera División",
+    "position": "Forward",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Danubio",
+      "Palermo",
+      "Napoli",
+      "Paris Saint-Germain",
+      "Manchester United",
+      "Valencia"
+    ]
+  },
+  {
+    "id": 45,
+    "name": "Luis Suárez",
+    "birthdate": "1987-01-24",
+    "club": "Inter Miami",
+    "league": "MLS",
+    "position": "Forward",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Nacional",
+      "Groningen",
+      "Ajax",
+      "Liverpool",
+      "Barcelona",
+      "Atlético Madrid",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 46,
+    "name": "Olivier Giroud",
+    "birthdate": "1986-09-30",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Grenoble",
+      "Tours",
+      "Montpellier",
+      "Arsenal",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 47,
+    "name": "Antoine Griezmann",
+    "birthdate": "1991-03-21",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Real Sociedad",
+      "Atlético Madrid",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 48,
+    "name": "Álvaro Morata",
+    "birthdate": "1992-10-23",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid",
+      "Juventus",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 49,
+    "name": "Edin Džeko",
+    "birthdate": "1986-03-17",
+    "club": "Fenerbahçe",
+    "league": "Süper Lig",
+    "position": "Forward",
+    "nationality": "Bosnia and Herzegovina",
+    "past_clubs": [
+      "Željezničar",
+      "Teplice",
+      "Wolfsburg",
+      "Manchester City",
+      "Roma",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 50,
+    "name": "Thomas Müller",
+    "birthdate": "1989-09-13",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 51,
+    "name": "Oliver Kahn",
+    "birthdate": "1969-06-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Karlsruhe",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 52,
+    "name": "Kaká",
+    "birthdate": "1982-04-22",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Milan",
+      "Real Madrid",
+      "Orlando City"
+    ]
+  },
+  {
+    "id": 53,
+    "name": "Clarence Seedorf",
+    "birthdate": "1976-04-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Sampdoria",
+      "Real Madrid",
+      "Inter Milan",
+      "Milan",
+      "Botafogo"
+    ]
+  },
+  {
+    "id": 54,
+    "name": "Andrea Pirlo",
+    "birthdate": "1979-05-19",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Brescia",
+      "Inter Milan",
+      "Reggina",
+      "Milan",
+      "Juventus",
+      "New York City"
+    ]
+  },
+  {
+    "id": 55,
+    "name": "Frank Lampard",
+    "birthdate": "1978-06-20",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "West Ham",
+      "Swansea City",
+      "Chelsea",
+      "Manchester City",
+      "New York City"
+    ]
+  },
+  {
+    "id": 56,
+    "name": "Steven Gerrard",
+    "birthdate": "1980-05-30",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Liverpool",
+      "LA Galaxy"
+    ]
+  },
+  {
+    "id": 57,
+    "name": "Paul Scholes",
+    "birthdate": "1974-11-16",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 58,
+    "name": "Ryan Giggs",
+    "birthdate": "1973-11-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Wales",
+    "past_clubs": [
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 59,
+    "name": "David Beckham",
+    "birthdate": "1975-05-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester United",
+      "Preston North End",
+      "Real Madrid",
+      "LA Galaxy",
+      "Milan",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 60,
+    "name": "Patrick Vieira",
+    "birthdate": "1976-06-23",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Cannes",
+      "Milan",
+      "Arsenal",
+      "Juventus",
+      "Inter Milan",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 61,
+    "name": "Roy Keane",
+    "birthdate": "1971-08-10",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Ireland",
+    "past_clubs": [
+      "Cobh Ramblers",
+      "Nottingham Forest",
+      "Manchester United",
+      "Celtic"
+    ]
+  },
+  {
+    "id": 62,
+    "name": "Michael Ballack",
+    "birthdate": "1976-09-26",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Chemnitzer FC",
+      "Kaiserslautern",
+      "Bayer Leverkusen",
+      "Bayern Munich",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 63,
+    "name": "Lothar Matthäus",
+    "birthdate": "1961-03-21",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Borussia Mönchengladbach",
+      "Bayern Munich",
+      "Inter Milan",
+      "New York Red Bulls"
+    ]
+  },
+  {
+    "id": 64,
+    "name": "Sócrates",
+    "birthdate": "1954-02-19",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Botafogo-SP",
+      "Corinthians",
+      "Fiorentina",
+      "Flamengo",
+      "Santos"
+    ]
+  },
+  {
+    "id": 65,
+    "name": "Zico",
+    "birthdate": "1953-03-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Udinese",
+      "Kashima Antlers"
+    ]
+  },
+  {
+    "id": 66,
+    "name": "Rui Costa",
+    "birthdate": "1972-03-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Fiorentina",
+      "Milan"
+    ]
+  },
+  {
+    "id": 67,
+    "name": "Deco",
+    "birthdate": "1977-08-27",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Corinthians",
+      "Benfica",
+      "Porto",
+      "Barcelona",
+      "Chelsea",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 68,
+    "name": "Gennaro Gattuso",
+    "birthdate": "1978-01-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Perugia",
+      "Rangers",
+      "Salernitana",
+      "Milan",
+      "Sion"
+    ]
+  },
+  {
+    "id": 69,
+    "name": "Iker Muniain",
+    "birthdate": "1992-12-19",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Athletic Bilbao",
+      "Al-Qadisiyah"
+    ]
+  },
+  {
+    "id": 70,
+    "name": "Bastian Schweinsteiger",
+    "birthdate": "1984-08-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "Manchester United",
+      "Chicago Fire"
+    ]
+  },
+  {
+    "id": 71,
+    "name": "Javier Mascherano",
+    "birthdate": "1984-06-08",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate",
+      "Corinthians",
+      "West Ham",
+      "Liverpool",
+      "Barcelona",
+      "Hebei China Fortune",
+      "Estudiantes"
+    ]
+  },
+  {
+    "id": 72,
+    "name": "Daniele De Rossi",
+    "birthdate": "1983-07-24",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Roma",
+      "Boca Juniors"
+    ]
+  },
+  {
+    "id": 73,
+    "name": "Arturo Vidal",
+    "birthdate": "1987-05-22",
+    "club": "Colo-Colo",
+    "league": "Primera División",
+    "position": "Midfielder",
+    "nationality": "Chile",
+    "past_clubs": [
+      "Colo-Colo",
+      "Bayer Leverkusen",
+      "Juventus",
+      "Bayern Munich",
+      "Barcelona",
+      "Inter Milan",
+      "Flamengo",
+      "Athletico Paranaense"
+    ]
+  },
+  {
+    "id": 74,
+    "name": "Paulinho",
+    "birthdate": "1988-07-25",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Pão de Açúcar",
+      "Bragantino",
+      "Corinthians",
+      "Tottenham",
+      "Guangzhou Evergrande",
+      "Barcelona",
+      "Al-Ahli",
+      "Al-Taawoun"
+    ]
+  },
+  {
+    "id": 75,
+    "name": "Fernandão",
+    "birthdate": "1978-03-18",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Goiás",
+      "Olympique Marseille",
+      "Toulouse",
+      "Internacional",
+      "Al-Gharafa",
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 76,
+    "name": "Fred",
+    "birthdate": "1983-10-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "América Mineiro",
+      "Cruzeiro",
+      "Lyon",
+      "Fluminense",
+      "Atlético Mineiro"
+    ]
+  },
+  {
+    "id": 77,
+    "name": "Diego Forlán",
+    "birthdate": "1979-05-19",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Independiente",
+      "Manchester United",
+      "Villarreal",
+      "Atlético Madrid",
+      "Inter Milan",
+      "Internacional",
+      "Cerezo Osaka",
+      "Peñarol",
+      "Mumbai City",
+      "Kitchee"
+    ]
+  },
+  {
+    "id": 78,
+    "name": "Hugo Sánchez",
+    "birthdate": "1958-07-11",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Mexico",
+    "past_clubs": [
+      "UNAM",
+      "Atlético Madrid",
+      "Real Madrid",
+      "América",
+      "Rayo Vallecano",
+      "Atlante",
+      "Dallas Burn"
+    ]
+  },
+  {
+    "id": 79,
+    "name": "Romário",
+    "birthdate": "1966-01-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "PSV",
+      "Barcelona",
+      "Flamengo",
+      "Valencia",
+      "Al-Sadd",
+      "Miami FC",
+      "Adelaide United",
+      "America-RJ",
+      "Brasiliense"
+    ]
+  },
+  {
+    "id": 80,
+    "name": "Bebeto",
+    "birthdate": "1964-02-16",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vitória",
+      "Flamengo",
+      "Vasco da Gama",
+      "Deportivo La Coruña",
+      "Sevilla",
+      "Cruzeiro",
+      "Botafogo",
+      "Toros Neza",
+      "Kashima Antlers",
+      "Al-Ittihad"
+    ]
+  },
+  {
+    "id": 81,
+    "name": "Careca",
+    "birthdate": "1960-10-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Guarani",
+      "São Paulo",
+      "Napoli",
+      "Kashiwa Reysol",
+      "Santos"
+    ]
+  },
+  {
+    "id": 82,
+    "name": "Jürgen Klinsmann",
+    "birthdate": "1964-07-30",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Stuttgart",
+      "Inter Milan",
+      "Monaco",
+      "Tottenham",
+      "Bayern Munich",
+      "Sampdoria"
+    ]
+  },
+  {
+    "id": 83,
+    "name": "Rudi Völler",
+    "birthdate": "1960-04-13",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "1860 Munich",
+      "Werder Bremen",
+      "Roma",
+      "Marseille",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 84,
+    "name": "Karl-Heinz Rummenigge",
+    "birthdate": "1955-09-25",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "Inter Milan",
+      "Servette"
+    ]
+  },
+  {
+    "id": 85,
+    "name": "Paolo Rossi",
+    "birthdate": "1956-09-23",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Juventus",
+      "Vicenza",
+      "Perugia",
+      "Milan",
+      "Hellas Verona"
+    ]
+  },
+  {
+    "id": 86,
+    "name": "Roberto Baggio",
+    "birthdate": "1967-02-18",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Vicenza",
+      "Fiorentina",
+      "Juventus",
+      "Milan",
+      "Bologna",
+      "Inter Milan",
+      "Brescia"
+    ]
+  },
+  {
+    "id": 87,
+    "name": "Alessandro Del Piero",
+    "birthdate": "1974-11-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Padova",
+      "Juventus",
+      "Sydney FC",
+      "Delhi Dynamos"
+    ]
+  },
+  {
+    "id": 88,
+    "name": "Francesco Totti",
+    "birthdate": "1976-09-27",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Roma"
+    ]
+  },
+  {
+    "id": 89,
+    "name": "Filippo Inzaghi",
+    "birthdate": "1973-08-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Piacenza",
+      "Parma",
+      "Atalanta",
+      "Juventus",
+      "Milan"
+    ]
+  },
+  {
+    "id": 90,
+    "name": "Hernán Crespo",
+    "birthdate": "1975-07-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate",
+      "Parma",
+      "Lazio",
+      "Inter Milan",
+      "Chelsea",
+      "Milan",
+      "Genoa"
+    ]
+  },
+  {
+    "id": 91,
+    "name": "Gabriel Batistuta",
+    "birthdate": "1969-02-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Newell's Old Boys",
+      "River Plate",
+      "Boca Juniors",
+      "Fiorentina",
+      "Roma",
+      "Al-Arabi"
+    ]
+  },
+  {
+    "id": 92,
+    "name": "Claudio Caniggia",
+    "birthdate": "1967-01-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate",
+      "Verona",
+      "Atalanta",
+      "Roma",
+      "Benfica",
+      "Boca Juniors",
+      "Dundee",
+      "Rangers",
+      "Qatar SC"
+    ]
+  },
+  {
+    "id": 93,
+    "name": "Enzo Francescoli",
+    "birthdate": "1961-11-12",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Montevideo Wanderers",
+      "River Plate",
+      "RC Paris",
+      "Marseille",
+      "Cagliari",
+      "Torino"
+    ]
+  },
+  {
+    "id": 94,
+    "name": "Obdulio Varela",
+    "birthdate": "1917-09-20",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Montevideo Wanderers",
+      "Peñarol"
+    ]
+  },
+  {
+    "id": 95,
+    "name": "Teófilo Cubillas",
+    "birthdate": "1949-03-08",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Peru",
+    "past_clubs": [
+      "Alianza Lima",
+      "Basel",
+      "Porto",
+      "Fort Lauderdale Strikers"
+    ]
+  },
+  {
+    "id": 96,
+    "name": "Elias Figueroa",
+    "birthdate": "1946-10-25",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Chile",
+    "past_clubs": [
+      "Unión La Calera",
+      "Santiago Wanderers",
+      "Peñarol",
+      "Internacional",
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 97,
+    "name": "Iván Zamorano",
+    "birthdate": "1967-01-18",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Chile",
+    "past_clubs": [
+      "Cobresal",
+      "St. Gallen",
+      "Sevilla",
+      "Real Madrid",
+      "Inter Milan",
+      "América"
+    ]
+  },
+  {
+    "id": 98,
+    "name": "Carlos Valderrama",
+    "birthdate": "1961-09-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Unión Magdalena",
+      "Millonarios",
+      "Deportivo Cali",
+      "Montpellier",
+      "Real Valladolid",
+      "Independiente Medellín",
+      "Tampa Bay Mutiny",
+      "Miami Fusion",
+      "Colorado Rapids"
+    ]
+  },
+  {
+    "id": 99,
+    "name": "René Higuita",
+    "birthdate": "1966-08-27",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Millonarios",
+      "Atlético Nacional",
+      "Real Valladolid",
+      "Independiente Medellín",
+      "Aucas"
+    ]
+  },
+  {
+    "id": 100,
+    "name": "Óscar Córdoba",
+    "birthdate": "1970-02-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Deportivo Cali",
+      "América de Cali",
+      "Boca Juniors",
+      "Perugia",
+      "Beşiktaş",
+      "Antalyaspor",
+      "Millonarios"
+    ]
+  },
+  {
+    "id": 101,
+    "name": "Ronaldinho Gaúcho",
+    "birthdate": "1980-03-21",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Grêmio",
+      "Paris Saint-Germain",
+      "Barcelona",
+      "Milan",
+      "Flamengo",
+      "Atlético Mineiro",
+      "Fluminense",
+      "Querétaro"
+    ]
+  },
+  {
+    "id": 102,
+    "name": "Rivaldo",
+    "birthdate": "1972-04-19",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santa Cruz",
+      "Mogi Mirim",
+      "Corinthians",
+      "Palmeiras",
+      "Deportivo La Coruña",
+      "Barcelona",
+      "Milan",
+      "Cruzeiro",
+      "Olympiacos",
+      "AEK Athens",
+      "Bunyodkor",
+      "São Paulo",
+      "Kabuscorp"
+    ]
+  },
+  {
+    "id": 103,
+    "name": "Ronaldo Nazário",
+    "birthdate": "1976-09-18",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "PSV",
+      "Barcelona",
+      "Inter Milan",
+      "Real Madrid",
+      "Milan",
+      "Corinthians"
+    ]
+  },
+  {
+    "id": 104,
+    "name": "Pelé",
+    "birthdate": "1940-10-23",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "New York Cosmos"
+    ]
+  },
+  {
+    "id": 105,
+    "name": "Diego Maradona",
+    "birthdate": "1960-10-30",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Argentinos Juniors",
+      "Boca Juniors",
+      "Barcelona",
+      "Napoli",
+      "Sevilla",
+      "Newell's Old Boys"
+    ]
+  },
+  {
+    "id": 106,
+    "name": "Johan Cruyff",
+    "birthdate": "1947-04-25",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Barcelona",
+      "Feyenoord",
+      "Los Angeles Aztecs",
+      "Washington Diplomats",
+      "Levante"
+    ]
+  },
+  {
+    "id": 107,
+    "name": "Franz Beckenbauer",
+    "birthdate": "1945-09-11",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "New York Cosmos",
+      "Hamburger SV"
+    ]
+  },
+  {
+    "id": 108,
+    "name": "Eusébio",
+    "birthdate": "1942-01-25",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Boston Minutemen",
+      "Monterrey",
+      "Toronto Metros-Croatia",
+      "Beira-Mar",
+      "Las Vegas Quicksilvers",
+      "União de Tomar",
+      "New Jersey Americans"
+    ]
+  },
+  {
+    "id": 109,
+    "name": "George Best",
+    "birthdate": "1946-05-22",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Winger",
+    "nationality": "Northern Ireland",
+    "past_clubs": [
+      "Manchester United",
+      "Dunstable Town",
+      "Stockport County",
+      "Cork Celtic",
+      "Los Angeles Aztecs",
+      "Fulham",
+      "Fort Lauderdale Strikers",
+      "Hibernian",
+      "San Jose Earthquakes",
+      "Hong Kong Rangers",
+      "Bournemouth",
+      "Brisbane Lions",
+      "Tobermore United"
+    ]
+  },
+  {
+    "id": 110,
+    "name": "Ferenc Puskás",
+    "birthdate": "1927-04-01",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Budapest Honvéd",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 111,
+    "name": "Alfredo Di Stéfano",
+    "birthdate": "1926-07-04",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina/Spain",
+    "past_clubs": [
+      "River Plate",
+      "Huracán",
+      "Millonarios",
+      "Real Madrid",
+      "Espanyol"
+    ]
+  },
+  {
+    "id": 112,
+    "name": "Bobby Charlton",
+    "birthdate": "1937-10-11",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester United",
+      "Preston North End"
+    ]
+  },
+  {
+    "id": 113,
+    "name": "Garrincha",
+    "birthdate": "1933-10-28",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Winger",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Botafogo",
+      "Corinthians",
+      "Atlético Junior",
+      "Flamengo",
+      "Olaria"
+    ]
+  },
+  {
+    "id": 114,
+    "name": "Thierry Henry",
+    "birthdate": "1977-08-17",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Monaco",
+      "Juventus",
+      "Arsenal",
+      "Barcelona",
+      "New York Red Bulls"
+    ]
+  },
+  {
+    "id": 115,
+    "name": "Zinedine Zidane",
+    "birthdate": "1972-06-23",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Cannes",
+      "Bordeaux",
+      "Juventus",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 116,
+    "name": "Michel Platini",
+    "birthdate": "1955-06-21",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Nancy",
+      "Saint-Étienne",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 117,
+    "name": "Eric Cantona",
+    "birthdate": "1966-05-24",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Auxerre",
+      "Martigues",
+      "Marseille",
+      "Bordeaux",
+      "Montpellier",
+      "Nîmes",
+      "Leeds United",
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 118,
+    "name": "Just Fontaine",
+    "birthdate": "1933-08-18",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "USM Casablanca",
+      "Nice",
+      "Reims"
+    ]
+  },
+  {
+    "id": 119,
+    "name": "Lev Yashin",
+    "birthdate": "1929-10-22",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Soviet Union",
+    "past_clubs": [
+      "Dynamo Moscow"
+    ]
+  },
+  {
+    "id": 120,
+    "name": "Sándor Kocsis",
+    "birthdate": "1929-09-21",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Ferencváros",
+      "Budapest Honvéd",
+      "Young Fellows Zürich",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 121,
+    "name": "Dixie Dean",
+    "birthdate": "1907-01-22",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Tranmere Rovers",
+      "Everton",
+      "Notts County",
+      "Sligo Rovers",
+      "Ashton United",
+      "Hurst"
+    ]
+  },
+  {
+    "id": 122,
+    "name": "Stanley Matthews",
+    "birthdate": "1915-02-01",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Winger",
+    "nationality": "England",
+    "past_clubs": [
+      "Stoke City",
+      "Blackpool"
+    ]
+  },
+  {
+    "id": 123,
+    "name": "John Charles",
+    "birthdate": "1931-12-27",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward/Defender",
+    "nationality": "Wales",
+    "past_clubs": [
+      "Leeds United",
+      "Juventus",
+      "Roma",
+      "Cardiff City",
+      "Hereford United"
+    ]
+  },
+  {
+    "id": 124,
+    "name": "Gordon Banks",
+    "birthdate": "1937-12-30",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "England",
+    "past_clubs": [
+      "Chesterfield",
+      "Leicester City",
+      "Stoke City",
+      "Fort Lauderdale Strikers"
+    ]
+  },
+  {
+    "id": 125,
+    "name": "Bobby Moore",
+    "birthdate": "1941-04-12",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "West Ham United",
+      "Fulham",
+      "San Antonio Thunder",
+      "Seattle Sounders",
+      "Carolina Lightnin'"
+    ]
+  },
+  {
+    "id": 126,
+    "name": "Gerd Müller",
+    "birthdate": "1945-11-03",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "1861 Nördlingen",
+      "Bayern Munich",
+      "Fort Lauderdale Strikers"
+    ]
+  },
+  {
+    "id": 127,
+    "name": "Marco van Basten",
+    "birthdate": "1964-10-31",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Milan"
+    ]
+  },
+  {
+    "id": 128,
+    "name": "Dennis Bergkamp",
+    "birthdate": "1969-05-10",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Inter Milan",
+      "Arsenal"
+    ]
+  },
+  {
+    "id": 129,
+    "name": "Johan Neeskens",
+    "birthdate": "1951-09-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Barcelona",
+      "Cosmos"
+    ]
+  },
+  {
+    "id": 130,
+    "name": "Ruud Gullit",
+    "birthdate": "1962-09-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "HFC Haarlem",
+      "Feyenoord",
+      "PSV",
+      "Milan",
+      "Sampdoria",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 131,
+    "name": "Roland Nilsson",
+    "birthdate": "1963-11-27",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "IFK Göteborg",
+      "Sheffield Wednesday",
+      "Helsingborg",
+      "Coventry City"
+    ]
+  },
+  {
+    "id": 132,
+    "name": "Henrik Larsson",
+    "birthdate": "1971-09-20",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Högaborgs BK",
+      "Helsingborg",
+      "Feyenoord",
+      "Celtic",
+      "Barcelona",
+      "Manchester United",
+      "Råå"
+    ]
+  },
+  {
+    "id": 133,
+    "name": "Sven-Göran Eriksson",
+    "birthdate": "1948-02-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "KB Karlskoga",
+      "Degerfors IF",
+      "Örebro SK"
+    ]
+  },
+  {
+    "id": 134,
+    "name": "Tomas Brolin",
+    "birthdate": "1969-11-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Näsvikens IK",
+      "GIF Sundsvall",
+      "Parma",
+      "Leeds United",
+      "FC Zürich",
+      "Crystal Palace"
+    ]
+  },
+  {
+    "id": 135,
+    "name": "Glenn Strömberg",
+    "birthdate": "1960-01-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "IFK Göteborg",
+      "Benfica",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 136,
+    "name": "Gunnar Nordahl",
+    "birthdate": "1921-10-19",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Hörnefors IF",
+      "IFK Norrköping",
+      "Milan",
+      "Roma"
+    ]
+  },
+  {
+    "id": 137,
+    "name": "Giacinto Facchetti",
+    "birthdate": "1942-07-18",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 138,
+    "name": "Franco Baresi",
+    "birthdate": "1960-05-08",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Milan"
+    ]
+  },
+  {
+    "id": 139,
+    "name": "Giuseppe Meazza",
+    "birthdate": "1910-08-23",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Inter Milan",
+      "Milan",
+      "Juventus",
+      "Varese",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 140,
+    "name": "Gianni Rivera",
+    "birthdate": "1943-08-18",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Alessandria",
+      "Milan"
+    ]
+  },
+  {
+    "id": 141,
+    "name": "Dino Zoff",
+    "birthdate": "1942-02-28",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Udinese",
+      "Mantova",
+      "Napoli",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 142,
+    "name": "Cafu",
+    "birthdate": "1970-06-07",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Real Zaragoza",
+      "Palmeiras",
+      "Roma",
+      "Milan"
+    ]
+  },
+  {
+    "id": 143,
+    "name": "Roberto Carlos",
+    "birthdate": "1973-04-10",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "União São João",
+      "Palmeiras",
+      "Inter Milan",
+      "Real Madrid",
+      "Fenerbahçe",
+      "Corinthians",
+      "Anzhi Makhachkala",
+      "Delhi Dynamos"
+    ]
+  },
+  {
+    "id": 144,
+    "name": "Jairzinho",
+    "birthdate": "1944-12-25",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Botafogo",
+      "Marseille",
+      "Flamengo",
+      "Corinthians",
+      "Fast"
+    ]
+  },
+  {
+    "id": 145,
+    "name": "Falcão",
+    "birthdate": "1953-10-16",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Roma",
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 146,
+    "name": "Djalma Santos",
+    "birthdate": "1929-02-27",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Portuguesa",
+      "Palmeiras",
+      "Atlético Paranaense"
+    ]
+  },
+  {
+    "id": 147,
+    "name": "Nilton Santos",
+    "birthdate": "1925-05-16",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Botafogo"
+    ]
+  },
+  {
+    "id": 148,
+    "name": "Ademir de Menezes",
+    "birthdate": "1922-11-08",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Sport Recife",
+      "Vasco da Gama",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 149,
+    "name": "Leonidas da Silva",
+    "birthdate": "1913-09-06",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Sírio-Libanês",
+      "Bonsucesso",
+      "Flamengo",
+      "Peñarol",
+      "Vasco da Gama",
+      "Botafogo",
+      "São Paulo",
+      "Canto do Rio"
+    ]
+  },
+  {
+    "id": 150,
+    "name": "Nílton de Sordi",
+    "birthdate": "1931-02-14",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 151,
+    "name": "Paul Breitner",
+    "birthdate": "1951-09-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "Real Madrid",
+      "Eintracht Braunschweig"
+    ]
+  },
+  {
+    "id": 152,
+    "name": "Fritz Walter",
+    "birthdate": "1920-10-31",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Kaiserslautern"
+    ]
+  },
+  {
+    "id": 153,
+    "name": "Uwe Seeler",
+    "birthdate": "1936-11-05",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Hamburg",
+      "Cork Celtic"
+    ]
+  },
+  {
+    "id": 154,
+    "name": "Helmut Rahn",
+    "birthdate": "1929-08-16",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "SpVgg Altenessen",
+      "Rot-Weiss Essen",
+      "Meidericher SV",
+      "Sportclub Enschede"
+    ]
+  },
+  {
+    "id": 155,
+    "name": "Berti Vogts",
+    "birthdate": "1946-12-16",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Borussia Mönchengladbach"
+    ]
+  },
+  {
+    "id": 156,
+    "name": "Ferenc Deák",
+    "birthdate": "1922-01-16",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Szentlőrinci AC",
+      "Ferencváros",
+      "Fiorentina",
+      "Újpesti Dózsa"
+    ]
+  },
+  {
+    "id": 157,
+    "name": "József Bozsik",
+    "birthdate": "1925-11-28",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Budapest Honvéd"
+    ]
+  },
+  {
+    "id": 158,
+    "name": "Florian Albert",
+    "birthdate": "1941-09-15",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Ferencváros"
+    ]
+  },
+  {
+    "id": 159,
+    "name": "Zoltán Czibor",
+    "birthdate": "1929-08-23",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Komárom",
+      "Ferencváros",
+      "Budapest Honvéd",
+      "Barcelona",
+      "Espanyol"
+    ]
+  },
+  {
+    "id": 160,
+    "name": "Gyula Grosics",
+    "birthdate": "1926-02-04",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "Dorog",
+      "Budapest Honvéd",
+      "Tatabánya"
+    ]
+  },
+  {
+    "id": 161,
+    "name": "László Kubala",
+    "birthdate": "1927-06-10",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Hungary/Spain",
+    "past_clubs": [
+      "Ferencváros",
+      "Vasas SC",
+      "Pro Patria",
+      "Barcelona",
+      "Espanyol",
+      "FC Zürich"
+    ]
+  },
+  {
+    "id": 162,
+    "name": "Robin van Persie",
+    "birthdate": "1983-08-06",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Feyenoord",
+      "Arsenal",
+      "Manchester United",
+      "Fenerbahçe"
+    ]
+  },
+  {
+    "id": 163,
+    "name": "Arjen Robben",
+    "birthdate": "1984-01-23",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Winger",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Groningen",
+      "PSV",
+      "Chelsea",
+      "Real Madrid",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 164,
+    "name": "Wesley Sneijder",
+    "birthdate": "1984-06-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Real Madrid",
+      "Inter Milan",
+      "Galatasaray",
+      "Nice",
+      "Al-Gharafa"
+    ]
+  },
+  {
+    "id": 165,
+    "name": "Klaas-Jan Huntelaar",
+    "birthdate": "1983-08-12",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "PSV",
+      "De Graafschap",
+      "AGOVV",
+      "Heerenveen",
+      "Ajax",
+      "Real Madrid",
+      "Milan",
+      "Schalke 04"
+    ]
+  },
+  {
+    "id": 166,
+    "name": "Giovanni van Bronckhorst",
+    "birthdate": "1975-02-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "RKC Waalwijk",
+      "Feyenoord",
+      "Rangers",
+      "Arsenal",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 167,
+    "name": "Edwin van der Sar",
+    "birthdate": "1970-10-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Juventus",
+      "Fulham",
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 168,
+    "name": "Patrick Kluivert",
+    "birthdate": "1976-07-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Milan",
+      "Barcelona",
+      "Newcastle United",
+      "Valencia",
+      "PSV",
+      "Lille"
+    ]
+  },
+  {
+    "id": 169,
+    "name": "Frank de Boer",
+    "birthdate": "1970-05-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Barcelona",
+      "Galatasaray",
+      "Rangers",
+      "Al-Rayyan",
+      "Al-Shamal"
+    ]
+  },
+  {
+    "id": 170,
+    "name": "Ronald de Boer",
+    "birthdate": "1970-05-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Twente",
+      "Barcelona",
+      "Rangers",
+      "Al-Rayyan",
+      "Al-Shamal"
+    ]
+  },
+  {
+    "id": 171,
+    "name": "Jaap Stam",
+    "birthdate": "1972-07-17",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Cambuur Leeuwarden",
+      "Willem II",
+      "PSV",
+      "Manchester United",
+      "Lazio",
+      "Milan",
+      "Ajax"
+    ]
+  },
+  {
+    "id": 172,
+    "name": "Rivellino",
+    "birthdate": "1946-01-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Fluminense",
+      "Al-Hilal"
+    ]
+  },
+  {
+    "id": 173,
+    "name": "Carlos Alberto Torres",
+    "birthdate": "1944-07-17",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Santos",
+      "Botafogo",
+      "Flamengo",
+      "New York Cosmos"
+    ]
+  },
+  {
+    "id": 174,
+    "name": "Mário Zagallo",
+    "birthdate": "1931-08-09",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "América",
+      "Flamengo",
+      "Botafogo"
+    ]
+  },
+  {
+    "id": 175,
+    "name": "Tostão",
+    "birthdate": "1947-01-25",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "América Mineiro",
+      "Cruzeiro"
+    ]
+  },
+  {
+    "id": 176,
+    "name": "Vavá",
+    "birthdate": "1934-11-12",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Sport Recife",
+      "Vasco da Gama",
+      "Atlético Madrid",
+      "Palmeiras",
+      "América"
+    ]
+  },
+  {
+    "id": 177,
+    "name": "Juan Román Riquelme",
+    "birthdate": "1978-06-24",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Argentinos Juniors",
+      "Boca Juniors",
+      "Barcelona",
+      "Villarreal"
+    ]
+  },
+  {
+    "id": 178,
+    "name": "Omar Sívori",
+    "birthdate": "1935-10-02",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina/Italy",
+    "past_clubs": [
+      "River Plate",
+      "Juventus",
+      "Napoli"
+    ]
+  },
+  {
+    "id": 179,
+    "name": "Diego Simeone",
+    "birthdate": "1970-04-28",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Vélez Sársfield",
+      "Pisa",
+      "Sevilla",
+      "Atlético Madrid",
+      "Inter Milan",
+      "Lazio",
+      "Racing Club"
+    ]
+  },
+  {
+    "id": 181,
+    "name": "Mario Kempes",
+    "birthdate": "1954-07-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Instituto",
+      "Rosario Central",
+      "Valencia",
+      "River Plate",
+      "Hercules",
+      "First Vienna",
+      "St Pölten",
+      "Kremser SC",
+      "Fernández Vial",
+      "Pelita Jaya"
+    ]
+  },
+  {
+    "id": 182,
+    "name": "Éric Abidal",
+    "birthdate": "1979-09-11",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Monaco",
+      "Lille",
+      "Lyon",
+      "Barcelona",
+      "Olympiacos"
+    ]
+  },
+  {
+    "id": 183,
+    "name": "Bixente Lizarazu",
+    "birthdate": "1969-12-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Bordeaux",
+      "Athletic Bilbao",
+      "Bayern Munich",
+      "Marseille"
+    ]
+  },
+  {
+    "id": 184,
+    "name": "Emmanuel Petit",
+    "birthdate": "1970-09-22",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Monaco",
+      "Arsenal",
+      "Barcelona",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 185,
+    "name": "Youri Djorkaeff",
+    "birthdate": "1968-03-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Grenoble",
+      "Strasbourg",
+      "Monaco",
+      "Paris Saint-Germain",
+      "Inter Milan",
+      "Kaiserslautern",
+      "Bolton",
+      "Blackburn Rovers",
+      "New York Red Bulls"
+    ]
+  },
+  {
+    "id": 186,
+    "name": "Robert Pirès",
+    "birthdate": "1973-10-29",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Metz",
+      "Marseille",
+      "Arsenal",
+      "Villarreal",
+      "Aston Villa",
+      "FC Goa"
+    ]
+  },
+  {
+    "id": 188,
+    "name": "Luis Figo",
+    "birthdate": "1972-11-04",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Barcelona",
+      "Real Madrid",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 189,
+    "name": "Mário Coluna",
+    "birthdate": "1935-08-06",
+    "club": "Deceased",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Lyon"
+    ]
+  },
+  {
+    "id": 190,
+    "name": "Paulo Futre",
+    "birthdate": "1966-02-28",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Winger",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Porto",
+      "Atlético Madrid",
+      "Benfica",
+      "Marseille",
+      "Reggiana",
+      "Milan",
+      "West Ham United",
+      "Yokohama Flügels"
+    ]
+  },
+  {
+    "id": 191,
+    "name": "Vítor Baía",
+    "birthdate": "1969-10-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Porto",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 192,
+    "name": "Fernando Couto",
+    "birthdate": "1969-08-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Porto",
+      "Parma",
+      "Barcelona",
+      "Lazio"
+    ]
+  },
+  {
+    "id": 193,
+    "name": "Nuno Gomes",
+    "birthdate": "1976-07-05",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Boavista",
+      "Benfica",
+      "Fiorentina",
+      "Braga",
+      "Blackburn Rovers"
+    ]
+  },
+  {
+    "id": 194,
+    "name": "Emilio Butragueño",
+    "birthdate": "1963-07-22",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid",
+      "Atlético Celaya"
+    ]
+  },
+  {
+    "id": 195,
+    "name": "Raúl",
+    "birthdate": "1977-06-27",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid",
+      "Schalke 04",
+      "Al Sadd",
+      "New York Cosmos"
+    ]
+  },
+  {
+    "id": 196,
+    "name": "Fernando Hierro",
+    "birthdate": "1968-03-23",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Valladolid",
+      "Real Madrid",
+      "Al Rayyan",
+      "Bolton Wanderers"
+    ]
+  },
+  {
+    "id": 197,
+    "name": "Iker Casillas",
+    "birthdate": "1981-05-20",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid",
+      "Porto"
+    ]
+  },
+  {
+    "id": 198,
+    "name": "Carles Puyol",
+    "birthdate": "1978-04-13",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 199,
+    "name": "David Villa",
+    "birthdate": "1981-12-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Sporting Gijón",
+      "Zaragoza",
+      "Valencia",
+      "Barcelona",
+      "Atlético Madrid",
+      "New York City",
+      "Melbourne City",
+      "Vissel Kobe"
+    ]
+  },
+  {
+    "id": 200,
+    "name": "Xavi",
+    "birthdate": "1980-01-25",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona",
+      "Al Sadd"
+    ]
+  },
+  {
+    "id": 201,
+    "name": "Andrés Iniesta",
+    "birthdate": "1984-05-11",
+    "club": "Emirates",
+    "league": "UAE Pro League",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona",
+      "Vissel Kobe"
+    ]
+  },
+  {
+    "id": 202,
+    "name": "Gianluigi Buffon",
+    "birthdate": "1978-01-28",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Parma",
+      "Juventus",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 203,
+    "name": "Ronaldinho",
+    "birthdate": "1980-03-21",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Grêmio",
+      "Paris Saint-Germain",
+      "Barcelona",
+      "Milan",
+      "Flamengo",
+      "Atlético Mineiro",
+      "Querétaro",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 205,
+    "name": "Wayne Rooney",
+    "birthdate": "1985-10-24",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Everton",
+      "Manchester United",
+      "DC United",
+      "Derby County"
+    ]
+  },
+  {
+    "id": 206,
+    "name": "Rio Ferdinand",
+    "birthdate": "1978-11-07",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "West Ham United",
+      "Leeds United",
+      "Manchester United",
+      "Queens Park Rangers"
+    ]
+  },
+  {
+    "id": 207,
+    "name": "John Terry",
+    "birthdate": "1980-12-07",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Aston Villa"
+    ]
+  },
+  {
+    "id": 208,
+    "name": "Gerard Piqué",
+    "birthdate": "1987-02-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Manchester United",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 209,
+    "name": "Andres Guardado",
+    "birthdate": "1986-09-28",
+    "club": "León",
+    "league": "Liga MX",
+    "position": "Midfielder",
+    "nationality": "Mexico",
+    "past_clubs": [
+      "Atlas",
+      "Deportivo La Coruña",
+      "Valencia",
+      "Bayer Leverkusen",
+      "PSV Eindhoven",
+      "Real Betis"
+    ]
+  },
+  {
+    "id": 210,
+    "name": "Javier Hernández",
+    "birthdate": "1988-06-01",
+    "club": "Chivas",
+    "league": "Liga MX",
+    "position": "Forward",
+    "nationality": "Mexico",
+    "past_clubs": [
+      "Guadalajara",
+      "Manchester United",
+      "Real Madrid",
+      "Bayer Leverkusen",
+      "West Ham United",
+      "Sevilla",
+      "LA Galaxy"
+    ]
+  },
+  {
+    "id": 212,
+    "name": "Nemanja Vidić",
+    "birthdate": "1981-10-21",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Serbia",
+    "past_clubs": [
+      "Red Star Belgrade",
+      "Spartak Moscow",
+      "Manchester United",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 213,
+    "name": "Ashley Cole",
+    "birthdate": "1980-12-20",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Arsenal",
+      "Chelsea",
+      "Roma",
+      "LA Galaxy",
+      "Derby County"
+    ]
+  },
+  {
+    "id": 214,
+    "name": "Samuel Eto'o",
+    "birthdate": "1981-03-10",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Cameroon",
+    "past_clubs": [
+      "Real Madrid",
+      "Mallorca",
+      "Barcelona",
+      "Inter Milan",
+      "Anzhi Makhachkala",
+      "Chelsea",
+      "Everton",
+      "Sampdoria",
+      "Antalyaspor",
+      "Konyaspor",
+      "Qatar SC"
+    ]
+  },
+  {
+    "id": 215,
+    "name": "Didier Drogba",
+    "birthdate": "1978-03-11",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Ivory Coast",
+    "past_clubs": [
+      "Le Mans",
+      "Guingamp",
+      "Marseille",
+      "Chelsea",
+      "Shanghai Shenhua",
+      "Galatasaray",
+      "Montreal Impact",
+      "Phoenix Rising"
+    ]
+  },
+  {
+    "id": 217,
+    "name": "Gareth Bale",
+    "birthdate": "1989-07-16",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Wales",
+    "past_clubs": [
+      "Southampton",
+      "Tottenham Hotspur",
+      "Real Madrid",
+      "Los Angeles FC"
+    ]
+  },
+  {
+    "id": 218,
+    "name": "Javier Zanetti",
+    "birthdate": "1973-08-10",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Talleres",
+      "Banfield",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 219,
+    "name": "Zlatan Ibrahimović",
+    "birthdate": "1981-10-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Malmö FF",
+      "Ajax",
+      "Juventus",
+      "Inter Milan",
+      "Barcelona",
+      "Milan",
+      "Paris Saint-Germain",
+      "Manchester United",
+      "LA Galaxy"
+    ]
+  },
+  {
+    "id": 224,
+    "name": "Marcelo",
+    "birthdate": "1988-05-12",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Real Madrid",
+      "Olympiacos"
+    ]
+  },
+  {
+    "id": 225,
+    "name": "Sergio Agüero",
+    "birthdate": "1988-06-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Independiente",
+      "Atlético Madrid",
+      "Manchester City",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 226,
+    "name": "Nuno Mendes",
+    "birthdate": "2002-06-19",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP"
+    ]
+  },
+  {
+    "id": 227,
+    "name": "Rúben Dias",
+    "birthdate": "1997-05-14",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica"
+    ]
+  },
+  {
+    "id": 228,
+    "name": "Bernardo Silva",
+    "birthdate": "1994-08-10",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Monaco"
+    ]
+  },
+  {
+    "id": 229,
+    "name": "João Cancelo",
+    "birthdate": "1994-05-27",
+    "club": "Al-Hilal",
+    "league": "Saudi Pro League",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Valencia",
+      "Inter Milan",
+      "Juventus",
+      "Manchester City",
+      "Bayern Munich",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 230,
+    "name": "Rafael Leão",
+    "birthdate": "1999-06-10",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Lille"
+    ]
+  },
+  {
+    "id": 231,
+    "name": "Roberto Firmino",
+    "birthdate": "1991-10-02",
+    "club": "Al-Ahli",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Figueirense",
+      "Hoffenheim",
+      "Liverpool"
+    ]
+  },
+  {
+    "id": 232,
+    "name": "Philippe Coutinho",
+    "birthdate": "1992-06-12",
+    "club": "Al-Duhail",
+    "league": "Qatar Stars League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Inter Milan",
+      "Espanyol",
+      "Liverpool",
+      "Barcelona",
+      "Bayern Munich",
+      "Aston Villa"
+    ]
+  },
+  {
+    "id": 233,
+    "name": "Richarlison",
+    "birthdate": "1997-05-10",
+    "club": "Tottenham",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "América Mineiro",
+      "Fluminense",
+      "Watford",
+      "Everton"
+    ]
+  },
+  {
+    "id": 234,
+    "name": "Alisson",
+    "birthdate": "1992-10-02",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Roma"
+    ]
+  },
+  {
+    "id": 235,
+    "name": "Gabriel Jesus",
+    "birthdate": "1997-04-03",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 237,
+    "name": "Rodrygo",
+    "birthdate": "2001-01-09",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos"
+    ]
+  },
+  {
+    "id": 238,
+    "name": "Éder Militão",
+    "birthdate": "1998-01-18",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Porto"
+    ]
+  },
+  {
+    "id": 240,
+    "name": "Sadio Mané",
+    "birthdate": "1992-04-10",
+    "club": "Al-Nassr",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "Senegal",
+    "past_clubs": [
+      "Metz",
+      "Red Bull Salzburg",
+      "Southampton",
+      "Liverpool",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 241,
+    "name": "Thibaut Courtois",
+    "birthdate": "1992-05-11",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Goalkeeper",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Genk",
+      "Atlético Madrid",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 242,
+    "name": "Dani Carvajal",
+    "birthdate": "1992-01-11",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 243,
+    "name": "Federico Valverde",
+    "birthdate": "1998-07-22",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Peñarol",
+      "Deportivo La Coruña"
+    ]
+  },
+  {
+    "id": 244,
+    "name": "Eduardo Camavinga",
+    "birthdate": "2002-11-10",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Rennes"
+    ]
+  },
+  {
+    "id": 245,
+    "name": "Xabi Alonso",
+    "birthdate": "1981-11-25",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Manager",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Sociedad",
+      "Liverpool",
+      "Real Madrid",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 246,
+    "name": "Kim Min-jae",
+    "birthdate": "1996-11-15",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "South Korea",
+    "past_clubs": [
+      "Jeonbuk Hyundai Motors",
+      "Beijing Guoan",
+      "Fenerbahçe",
+      "Napoli"
+    ]
+  },
+  {
+    "id": 247,
+    "name": "William Saliba",
+    "birthdate": "2001-03-24",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Saint-Étienne",
+      "Nice",
+      "Marseille"
+    ]
+  },
+  {
+    "id": 248,
+    "name": "Bukayo Saka",
+    "birthdate": "2001-09-05",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 249,
+    "name": "Declan Rice",
+    "birthdate": "1999-01-14",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "West Ham United"
+    ]
+  },
+  {
+    "id": 250,
+    "name": "Martin Ødegaard",
+    "birthdate": "1998-12-17",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Strømsgodset",
+      "Real Madrid",
+      "Heerenveen",
+      "Vitesse",
+      "Real Sociedad"
+    ]
+  },
+  {
+    "id": 251,
+    "name": "Thomas Partey",
+    "birthdate": "1993-06-13",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Ghana",
+    "past_clubs": [
+      "Atlético Madrid",
+      "Mallorca",
+      "Almería"
+    ]
+  },
+  {
+    "id": 252,
+    "name": "Cole Palmer",
+    "birthdate": "2002-05-06",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 253,
+    "name": "Enzo Fernández",
+    "birthdate": "2001-01-17",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate",
+      "Defensa y Justicia",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 254,
+    "name": "Moisés Caicedo",
+    "birthdate": "2001-11-02",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Ecuador",
+    "past_clubs": [
+      "Independiente del Valle",
+      "Brighton & Hove Albion"
+    ]
+  },
+  {
+    "id": 255,
+    "name": "Marc Cucurella",
+    "birthdate": "1998-07-22",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona",
+      "Eibar",
+      "Getafe",
+      "Brighton & Hove Albion"
+    ]
+  },
+  {
+    "id": 257,
+    "name": "Marcus Rashford",
+    "birthdate": "1997-10-31",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 258,
+    "name": "Mason Mount",
+    "birthdate": "1999-01-10",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Vitesse",
+      "Derby County"
+    ]
+  },
+  {
+    "id": 259,
+    "name": "Lisandro Martínez",
+    "birthdate": "1998-01-18",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Newell's Old Boys",
+      "Defensa y Justicia",
+      "Ajax"
+    ]
+  },
+  {
+    "id": 260,
+    "name": "Bruno Guimarães",
+    "birthdate": "1997-11-16",
+    "club": "Newcastle United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Audax",
+      "Athletico Paranaense",
+      "Lyon"
+    ]
+  },
+  {
+    "id": 261,
+    "name": "Alexander Isak",
+    "birthdate": "1999-09-21",
+    "club": "Newcastle United",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "AIK",
+      "Borussia Dortmund",
+      "Willem II",
+      "Real Sociedad"
+    ]
+  },
+  {
+    "id": 262,
+    "name": "Heung-min Son",
+    "birthdate": "1992-07-08",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "South Korea",
+    "past_clubs": [
+      "Hamburger SV",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 263,
+    "name": "James Maddison",
+    "birthdate": "1996-11-23",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Coventry City",
+      "Norwich City",
+      "Aberdeen",
+      "Leicester City"
+    ]
+  },
+  {
+    "id": 264,
+    "name": "Cristian Romero",
+    "birthdate": "1998-04-27",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Belgrano",
+      "Genoa",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 265,
+    "name": "Alexis Mac Allister",
+    "birthdate": "1998-12-24",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Argentinos Juniors",
+      "Boca Juniors",
+      "Brighton & Hove Albion"
+    ]
+  },
+  {
+    "id": 266,
+    "name": "Dominik Szoboszlai",
+    "birthdate": "2000-10-25",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Hungary",
+    "past_clubs": [
+      "FC Liefering",
+      "Red Bull Salzburg",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 267,
+    "name": "Trent Alexander-Arnold",
+    "birthdate": "1998-10-07",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 268,
+    "name": "Andrew Robertson",
+    "birthdate": "1994-03-11",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Scotland",
+    "past_clubs": [
+      "Queen's Park",
+      "Dundee United",
+      "Hull City"
+    ]
+  },
+  {
+    "id": 269,
+    "name": "Jeremy Doku",
+    "birthdate": "2002-05-27",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Anderlecht",
+      "Rennes"
+    ]
+  },
+  {
+    "id": 270,
+    "name": "Jack Grealish",
+    "birthdate": "1995-09-10",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Aston Villa",
+      "Notts County"
+    ]
+  },
+  {
+    "id": 271,
+    "name": "Josko Gvardiol",
+    "birthdate": "2002-01-23",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Croatia",
+    "past_clubs": [
+      "Dinamo Zagreb",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 272,
+    "name": "Julian Alvarez",
+    "birthdate": "2000-01-31",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 273,
+    "name": "Mateo Kovacic",
+    "birthdate": "1994-05-06",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Croatia",
+    "past_clubs": [
+      "Dinamo Zagreb",
+      "Inter Milan",
+      "Real Madrid",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 274,
+    "name": "Ilkay Gündogan",
+    "birthdate": "1990-10-24",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bochum",
+      "Nürnberg",
+      "Borussia Dortmund",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 276,
+    "name": "Gavi",
+    "birthdate": "2004-08-05",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": []
+  },
+  {
+    "id": 277,
+    "name": "Lamine Yamal",
+    "birthdate": "2007-07-13",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": []
+  },
+  {
+    "id": 278,
+    "name": "Jules Koundé",
+    "birthdate": "1998-11-12",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Bordeaux",
+      "Sevilla"
+    ]
+  },
+  {
+    "id": 279,
+    "name": "Frenkie de Jong",
+    "birthdate": "1997-05-12",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Willem II",
+      "Ajax"
+    ]
+  },
+  {
+    "id": 280,
+    "name": "Ferran Torres",
+    "birthdate": "2000-02-29",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Valencia",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 281,
+    "name": "Ansu Fati",
+    "birthdate": "2002-10-31",
+    "club": "Brighton & Hove Albion",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 282,
+    "name": "David Alaba",
+    "birthdate": "1992-06-24",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Austria",
+    "past_clubs": [
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 283,
+    "name": "Antonio Rüdiger",
+    "birthdate": "1993-03-03",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Stuttgart",
+      "Roma",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 284,
+    "name": "Aurélien Tchouaméni",
+    "birthdate": "2000-01-27",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Bordeaux",
+      "Monaco"
+    ]
+  },
+  {
+    "id": 285,
+    "name": "Alexander Sorloth",
+    "birthdate": "1995-12-05",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Rosenborg",
+      "Bodø/Glimt",
+      "Midtjylland",
+      "Groningen",
+      "Crystal Palace",
+      "Gent",
+      "Trabzonspor",
+      "RB Leipzig",
+      "Real Sociedad",
+      "Villarreal"
+    ]
+  },
+  {
+    "id": 286,
+    "name": "Koke",
+    "birthdate": "1992-01-08",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": []
+  },
+  {
+    "id": 288,
+    "name": "Marcos Llorente",
+    "birthdate": "1995-01-30",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 289,
+    "name": "Mikel Oyarzabal",
+    "birthdate": "1997-04-21",
+    "club": "Real Sociedad",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": []
+  },
+  {
+    "id": 290,
+    "name": "Take Kubo",
+    "birthdate": "2001-06-04",
+    "club": "Real Sociedad",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Japan",
+    "past_clubs": [
+      "FC Tokyo",
+      "Yokohama F. Marinos",
+      "Real Madrid",
+      "Mallorca",
+      "Villarreal",
+      "Getafe"
+    ]
+  },
+  {
+    "id": 291,
+    "name": "Isco",
+    "birthdate": "1992-04-21",
+    "club": "Real Betis",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Valencia",
+      "Málaga",
+      "Real Madrid",
+      "Sevilla"
+    ]
+  },
+  {
+    "id": 292,
+    "name": "Ayoze Pérez",
+    "birthdate": "1993-07-29",
+    "club": "Villarreal",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Tenerife",
+      "Newcastle United",
+      "Leicester City",
+      "Real Betis"
+    ]
+  },
+  {
+    "id": 293,
+    "name": "Jadon Sancho",
+    "birthdate": "2000-03-25",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester City",
+      "Borussia Dortmund",
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 294,
+    "name": "Marco Reus",
+    "birthdate": "1989-05-31",
+    "club": "Los Angeles Galaxy",
+    "league": "MLS",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Rot Weiss Ahlen",
+      "Borussia Mönchengladbach",
+      "Borussia Dortmund"
+    ]
+  },
+  {
+    "id": 295,
+    "name": "Mats Hummels",
+    "birthdate": "1988-12-16",
+    "club": "Roma",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayern Munich",
+      "Borussia Dortmund"
+    ]
+  },
+  {
+    "id": 296,
+    "name": "Jamal Musiala",
+    "birthdate": "2003-02-26",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 297,
+    "name": "Leroy Sané",
+    "birthdate": "1996-01-11",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Schalke 04",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 298,
+    "name": "Alphonso Davies",
+    "birthdate": "2000-11-02",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Canada",
+    "past_clubs": [
+      "Vancouver Whitecaps"
+    ]
+  },
+  {
+    "id": 299,
+    "name": "Aleksandar Pavlovic",
+    "birthdate": "2004-05-03",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": []
+  },
+  {
+    "id": 300,
+    "name": "Léon Goretzka",
+    "birthdate": "1995-02-06",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bochum",
+      "Schalke 04"
+    ]
+  },
+  {
+    "id": 301,
+    "name": "Kingsley Coman",
+    "birthdate": "1996-06-13",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Paris Saint-Germain",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 302,
+    "name": "Serge Gnabry",
+    "birthdate": "1995-07-14",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Arsenal",
+      "West Bromwich Albion",
+      "Werder Bremen",
+      "Hoffenheim"
+    ]
+  },
+  {
+    "id": 303,
+    "name": "Dayot Upamecano",
+    "birthdate": "1998-10-27",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Red Bull Salzburg",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 304,
+    "name": "Eric Maxim Choupo-Moting",
+    "birthdate": "1989-03-23",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Cameroon",
+    "past_clubs": [
+      "Hamburg",
+      "Nürnberg",
+      "Mainz 05",
+      "Schalke 04",
+      "Stoke City",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 305,
+    "name": "Florian Wirtz",
+    "birthdate": "2003-05-03",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Köln"
+    ]
+  },
+  {
+    "id": 306,
+    "name": "Matthijs de Ligt",
+    "birthdate": "1999-08-12",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Juventus",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 307,
+    "name": "Noussair Mazraoui",
+    "birthdate": "1997-11-14",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Morocco",
+    "past_clubs": [
+      "Ajax"
+    ]
+  },
+  {
+    "id": 308,
+    "name": "Michael Olise",
+    "birthdate": "2001-12-12",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Reading",
+      "Crystal Palace"
+    ]
+  },
+  {
+    "id": 309,
+    "name": "Mathys Tel",
+    "birthdate": "2005-04-27",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Rennes"
+    ]
+  },
+  {
+    "id": 310,
+    "name": "Benjamin Šeško",
+    "birthdate": "2003-05-31",
+    "club": "RB Leipzig",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Slovenia",
+    "past_clubs": [
+      "Domzale",
+      "Red Bull Salzburg"
+    ]
+  },
+  {
+    "id": 311,
+    "name": "Dani Olmo",
+    "birthdate": "1998-05-07",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Espanyol",
+      "Dinamo Zagreb",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 312,
+    "name": "Loïs Openda",
+    "birthdate": "2000-02-16",
+    "club": "RB Leipzig",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Standard Liège",
+      "Club Brugge",
+      "Vitesse",
+      "Lens"
+    ]
+  },
+  {
+    "id": 313,
+    "name": "Christopher Nkunku",
+    "birthdate": "1997-11-14",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Paris Saint-Germain",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 314,
+    "name": "Jonas Hofmann",
+    "birthdate": "1992-07-14",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Hoffenheim",
+      "Borussia Dortmund",
+      "Borussia Mönchengladbach"
+    ]
+  },
+  {
+    "id": 315,
+    "name": "Robert Andrich",
+    "birthdate": "1994-09-22",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Hertha BSC",
+      "Dynamo Dresden",
+      "Wehen Wiesbaden",
+      "Heidenheim",
+      "Union Berlin"
+    ]
+  },
+  {
+    "id": 316,
+    "name": "Alejandro Grimaldo",
+    "birthdate": "1995-09-20",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona B",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 317,
+    "name": "Granit Xhaka",
+    "birthdate": "1992-09-27",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Switzerland",
+    "past_clubs": [
+      "Basel",
+      "Borussia Mönchengladbach",
+      "Arsenal"
+    ]
+  },
+  {
+    "id": 318,
+    "name": "Jeremie Frimpong",
+    "birthdate": "2000-12-10",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Manchester City",
+      "Celtic"
+    ]
+  },
+  {
+    "id": 319,
+    "name": "Victor Boniface",
+    "birthdate": "2000-12-23",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Nigeria",
+    "past_clubs": [
+      "Bodø/Glimt",
+      "Union Saint-Gilloise"
+    ]
+  },
+  {
+    "id": 320,
+    "name": "Piero Hincapié",
+    "birthdate": "2002-01-09",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Ecuador",
+    "past_clubs": [
+      "Independiente del Valle",
+      "Talleres"
+    ]
+  },
+  {
+    "id": 321,
+    "name": "Julian Brandt",
+    "birthdate": "1996-05-02",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Wolfsburg",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 322,
+    "name": "Karim Adeyemi",
+    "birthdate": "2002-01-18",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "SpVgg Unterhaching",
+      "Red Bull Salzburg"
+    ]
+  },
+  {
+    "id": 323,
+    "name": "Nico Schlotterbeck",
+    "birthdate": "1999-12-01",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "SC Freiburg",
+      "Union Berlin"
+    ]
+  },
+  {
+    "id": 324,
+    "name": "Niklas Süle",
+    "birthdate": "1995-09-03",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Hoffenheim",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 325,
+    "name": "Marcel Sabitzer",
+    "birthdate": "1994-03-17",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Austria",
+    "past_clubs": [
+      "Admira Wacker",
+      "Rapid Wien",
+      "RB Leipzig",
+      "Bayern Munich",
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 326,
+    "name": "Eden Hazard",
+    "birthdate": "1991-01-07",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Lille",
+      "Chelsea",
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 327,
+    "name": "Achraf Hakimi",
+    "birthdate": "1998-11-04",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Morocco",
+    "past_clubs": [
+      "Real Madrid",
+      "Borussia Dortmund",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 328,
+    "name": "Warren Zaïre-Emery",
+    "birthdate": "2006-03-08",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": []
+  },
+  {
+    "id": 329,
+    "name": "Vitinha",
+    "birthdate": "2000-02-13",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Porto",
+      "Wolverhampton Wanderers"
+    ]
+  },
+  {
+    "id": 330,
+    "name": "Ousmane Dembélé",
+    "birthdate": "1997-05-15",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Rennes",
+      "Borussia Dortmund",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 331,
+    "name": "Lucas Beraldo",
+    "birthdate": "2003-11-24",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 332,
+    "name": "Gianluigi Donnarumma",
+    "birthdate": "1999-02-25",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Goalkeeper",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Milan"
+    ]
+  },
+  {
+    "id": 333,
+    "name": "Willian",
+    "birthdate": "1988-08-09",
+    "club": "Fulham",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Shakhtar Donetsk",
+      "Anzhi Makhachkala",
+      "Chelsea",
+      "Arsenal"
+    ]
+  },
+  {
+    "id": 334,
+    "name": "Andreas Pereira",
+    "birthdate": "1996-01-01",
+    "club": "Fulham",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Manchester United",
+      "Granada",
+      "Valencia",
+      "Lazio",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 335,
+    "name": "João Victor",
+    "birthdate": "1998-10-27",
+    "club": "Vasco da Gama",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Benfica",
+      "Nantes"
+    ]
+  },
+  {
+    "id": 336,
+    "name": "Pedro",
+    "birthdate": "1997-06-20",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Fiorentina"
+    ]
+  },
+  {
+    "id": 337,
+    "name": "Douglas Luiz",
+    "birthdate": "1998-05-09",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Manchester City",
+      "Girona"
+    ]
+  },
+  {
+    "id": 338,
+    "name": "Gabriel Martinelli",
+    "birthdate": "2001-06-18",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Ituano"
+    ]
+  },
+  {
+    "id": 339,
+    "name": "Antônio Carlos Júnior",
+    "birthdate": "1993-03-07",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Avaí",
+      "Vitória",
+      "Flamengo",
+      "Palmeiras",
+      "Orlando City"
+    ]
+  },
+  {
+    "id": 340,
+    "name": "Lucas Veríssimo",
+    "birthdate": "1995-07-07",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Linense",
+      "Ponte Preta",
+      "Santos",
+      "Benfica",
+      "Al-Duhail"
+    ]
+  },
+  {
+    "id": 342,
+    "name": "Endrick",
+    "birthdate": "2006-07-21",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 343,
+    "name": "Aymeric Laporte",
+    "birthdate": "1994-05-27",
+    "club": "Al-Nassr",
+    "league": "Saudi Pro League",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Athletic Bilbao",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 344,
+    "name": "Nacho Fernández",
+    "birthdate": "1990-01-18",
+    "club": "Al-Qadsiah",
+    "league": "Saudi Pro League",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Real Madrid"
+    ]
+  },
+  {
+    "id": 345,
+    "name": "Raphinha",
+    "birthdate": "1996-12-14",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vitória Guimarães",
+      "Sporting CP",
+      "Rennes",
+      "Leeds United"
+    ]
+  },
+  {
+    "id": 346,
+    "name": "Darwin Núñez",
+    "birthdate": "1999-06-24",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Peñarol",
+      "Almería",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 347,
+    "name": "Ronald Araújo",
+    "birthdate": "1999-03-07",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Rentistas",
+      "Boston River",
+      "Barcelona B"
+    ]
+  },
+  {
+    "id": 349,
+    "name": "Alejandro Garnacho",
+    "birthdate": "2004-07-01",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Atlético Madrid"
+    ]
+  },
+  {
+    "id": 351,
+    "name": "Pau Torres",
+    "birthdate": "1997-01-16",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Villarreal",
+      "Málaga"
+    ]
+  },
+  {
+    "id": 352,
+    "name": "Emiliano Martínez",
+    "birthdate": "1992-09-02",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Independiente",
+      "Arsenal",
+      "Oxford United",
+      "Sheffield Wednesday",
+      "Rotherham United",
+      "Wolverhampton Wanderers",
+      "Getafe",
+      "Reading"
+    ]
+  },
+  {
+    "id": 353,
+    "name": "Marquinhos",
+    "birthdate": "1994-05-14",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Roma"
+    ]
+  },
+  {
+    "id": 354,
+    "name": "Ollie Watkins",
+    "birthdate": "1995-12-30",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Exeter City",
+      "Weston-super-Mare",
+      "Brentford"
+    ]
+  },
+  {
+    "id": 355,
+    "name": "Kobbie Mainoo",
+    "birthdate": "2005-04-19",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 356,
+    "name": "Kieran Trippier",
+    "birthdate": "1990-09-19",
+    "club": "Newcastle United",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester City",
+      "Barnsley",
+      "Burnley",
+      "Tottenham Hotspur",
+      "Atlético Madrid"
+    ]
+  },
+  {
+    "id": 357,
+    "name": "Anthony Gordon",
+    "birthdate": "2001-02-24",
+    "club": "Newcastle United",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Everton",
+      "Preston North End"
+    ]
+  },
+  {
+    "id": 358,
+    "name": "Marc Guéhi",
+    "birthdate": "2000-07-13",
+    "club": "Crystal Palace",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Swansea City"
+    ]
+  },
+  {
+    "id": 359,
+    "name": "Eberechi Eze",
+    "birthdate": "1998-06-29",
+    "club": "Crystal Palace",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Millwall",
+      "Wycombe Wanderers",
+      "Queens Park Rangers"
+    ]
+  },
+  {
+    "id": 360,
+    "name": "Morgan Gibbs-White",
+    "birthdate": "2000-01-27",
+    "club": "Nottingham Forest",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Wolverhampton Wanderers",
+      "Swansea City",
+      "Sheffield United"
+    ]
+  },
+  {
+    "id": 361,
+    "name": "Jean-Clair Todibo",
+    "birthdate": "1999-12-30",
+    "club": "West Ham United",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Toulouse",
+      "Barcelona",
+      "Schalke 04",
+      "Benfica",
+      "Nice"
+    ]
+  },
+  {
+    "id": 362,
+    "name": "Wesley Fofana",
+    "birthdate": "2000-12-17",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Saint-Étienne",
+      "Leicester City"
+    ]
+  },
+  {
+    "id": 363,
+    "name": "Matheus Cunha",
+    "birthdate": "1999-05-27",
+    "club": "Wolverhampton Wanderers",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Coritiba",
+      "Sion",
+      "RB Leipzig",
+      "Hertha BSC",
+      "Atlético Madrid"
+    ]
+  },
+  {
+    "id": 364,
+    "name": "Pedro Neto",
+    "birthdate": "2000-03-09",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Braga",
+      "Lazio",
+      "Wolverhampton Wanderers"
+    ]
+  },
+  {
+    "id": 365,
+    "name": "Kai Havertz",
+    "birthdate": "1999-06-11",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Bayer Leverkusen",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 366,
+    "name": "Ben White",
+    "birthdate": "1997-10-08",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Brighton & Hove Albion",
+      "Newport County",
+      "Peterborough United",
+      "Leeds United"
+    ]
+  },
+  {
+    "id": 367,
+    "name": "Igor Jesus",
+    "birthdate": "2001-02-12",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Coritiba",
+      "Shabab Al-Ahli"
+    ]
+  },
+  {
+    "id": 368,
+    "name": "João Félix",
+    "birthdate": "1999-11-10",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Atlético Madrid",
+      "Barcelona"
+    ]
+  },
+  {
+    "id": 370,
+    "name": "Alessandro Bastoni",
+    "birthdate": "1999-04-13",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Atalanta",
+      "Parma"
+    ]
+  },
+  {
+    "id": 371,
+    "name": "Hakan Çalhanoglu",
+    "birthdate": "1994-02-08",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "Turkey",
+    "past_clubs": [
+      "Karlsruher SC",
+      "Hamburg",
+      "Bayer Leverkusen",
+      "Milan"
+    ]
+  },
+  {
+    "id": 372,
+    "name": "Lautaro Martínez",
+    "birthdate": "1997-08-22",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Racing Club"
+    ]
+  },
+  {
+    "id": 373,
+    "name": "Dusan Vlahović",
+    "birthdate": "2000-01-28",
+    "club": "Juventus",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Serbia",
+    "past_clubs": [
+      "Partizan",
+      "Fiorentina"
+    ]
+  },
+  {
+    "id": 374,
+    "name": "Ademola Lookman",
+    "birthdate": "1997-10-20",
+    "club": "Atalanta",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Nigeria",
+    "past_clubs": [
+      "Charlton Athletic",
+      "Everton",
+      "RB Leipzig",
+      "Fulham",
+      "Leicester City"
+    ]
+  },
+  {
+    "id": 375,
+    "name": "Riccardo Calafiori",
+    "birthdate": "2002-05-19",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Roma",
+      "Genoa",
+      "Basel",
+      "Bologna"
+    ]
+  },
+  {
+    "id": 376,
+    "name": "Gabigol",
+    "birthdate": "1996-08-30",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Inter Milan",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 377,
+    "name": "Giorgian De Arrascaeta",
+    "birthdate": "1994-06-01",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Defensor Sporting",
+      "Cruzeiro"
+    ]
+  },
+  {
+    "id": 378,
+    "name": "Everton Ribeiro",
+    "birthdate": "1989-04-10",
+    "club": "Bahia",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "São Caetano",
+      "Coritiba",
+      "Cruzeiro",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 379,
+    "name": "Raphael Veiga",
+    "birthdate": "1995-06-19",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Coritiba",
+      "Atlético Paranaense"
+    ]
+  },
+  {
+    "id": 380,
+    "name": "Rony",
+    "birthdate": "1995-05-11",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Remo",
+      "Náutico",
+      "Albirex Niigata",
+      "Athletico Paranaense"
+    ]
+  },
+  {
+    "id": 381,
+    "name": "Weverton",
+    "birthdate": "1987-12-13",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Portuguesa",
+      "Atlético Paranaense"
+    ]
+  },
+  {
+    "id": 382,
+    "name": "Gustavo Gómez",
+    "birthdate": "1993-05-06",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Paraguay",
+    "past_clubs": [
+      "Libertad",
+      "Lanús",
+      "Milan"
+    ]
+  },
+  {
+    "id": 383,
+    "name": "Giuliano Galoppo",
+    "birthdate": "1999-06-18",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Banfield"
+    ]
+  },
+  {
+    "id": 384,
+    "name": "Luis Díaz",
+    "birthdate": "1997-01-13",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Atlético Junior",
+      "Porto"
+    ]
+  },
+  {
+    "id": 386,
+    "name": "Walter Kannemann",
+    "birthdate": "1991-03-14",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "San Lorenzo",
+      "Atlas"
+    ]
+  },
+  {
+    "id": 387,
+    "name": "Villasanti",
+    "birthdate": "1998-01-24",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Paraguay",
+    "past_clubs": [
+      "Cerro Porteño",
+      "Nacional"
+    ]
+  },
+  {
+    "id": 388,
+    "name": "Paulinho",
+    "birthdate": "2000-07-15",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 389,
+    "name": "Hulk",
+    "birthdate": "1986-07-25",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vitória",
+      "Kawasaki Frontale",
+      "Consadóle Sapporo",
+      "Tokyo Verdy",
+      "Porto",
+      "Zenit Saint Petersburg",
+      "Shanghai SIPG"
+    ]
+  },
+  {
+    "id": 390,
+    "name": "Evanilson",
+    "birthdate": "1999-10-06",
+    "club": "Bournemouth",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Porto"
+    ]
+  },
+  {
+    "id": 392,
+    "name": "Gerson",
+    "birthdate": "1997-05-20",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Roma",
+      "Fiorentina",
+      "Marseille"
+    ]
+  },
+  {
+    "id": 393,
+    "name": "Adryelson",
+    "birthdate": "1998-06-23",
+    "club": "Lyon",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Sport Recife",
+      "Al-Wasl",
+      "Botafogo"
+    ]
+  },
+  {
+    "id": 394,
+    "name": "Lucas Perri",
+    "birthdate": "1997-12-10",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Crystal Palace",
+      "Náutico"
+    ]
+  },
+  {
+    "id": 395,
+    "name": "Eduardo Vargas",
+    "birthdate": "1989-11-20",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Chile",
+    "past_clubs": [
+      "Cobreloa",
+      "Universidad de Chile",
+      "Napoli",
+      "Grêmio",
+      "Valencia",
+      "Queens Park Rangers",
+      "Hoffenheim",
+      "Tigres UANL"
+    ]
+  },
+  {
+    "id": 396,
+    "name": "João Paulo",
+    "birthdate": "1995-07-06",
+    "club": "Santos",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético GO",
+      "Botão",
+      "Atlético PR"
+    ]
+  },
+  {
+    "id": 397,
+    "name": "Valentim Germain",
+    "birthdate": "2006-03-17",
+    "club": "Lyon",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": []
+  },
+  {
+    "id": 398,
+    "name": "Rayan Cherki",
+    "birthdate": "2003-08-17",
+    "club": "Lyon",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": []
+  },
+  {
+    "id": 399,
+    "name": "Nemanja Matic",
+    "birthdate": "1988-08-01",
+    "club": "Lyon",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "Serbia",
+    "past_clubs": [
+      "Kolubara",
+      "Kosice",
+      "Vitesse",
+      "Benfica",
+      "Chelsea",
+      "Manchester United",
+      "Roma"
+    ]
+  },
+  {
+    "id": 400,
+    "name": "Marcos Leonardo",
+    "birthdate": "2003-05-02",
+    "club": "Benfica",
+    "league": "Primeira Liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos"
+    ]
+  },
+  {
+    "id": 401,
+    "name": "Everton Cebolinha",
+    "birthdate": "1996-03-22",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Grêmio",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 402,
+    "name": "Bruno Henrique",
+    "birthdate": "1990-12-30",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Goias",
+      "Wolfsburg",
+      "Santos"
+    ]
+  },
+  {
+    "id": 403,
+    "name": "De La Cruz",
+    "birthdate": "1997-06-01",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Liverpool FC (URU)",
+      "River Plate"
+    ]
+  },
+  {
+    "id": 404,
+    "name": "Rogério Ceni",
+    "birthdate": "1973-01-22",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Sinop",
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 405,
+    "name": "Cassão",
+    "birthdate": "1992-06-16",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "PSV",
+      "Sparta Rotterdam",
+      "Flamengo",
+      "Vitória",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 406,
+    "name": "Fábio Santos",
+    "birthdate": "1985-09-16",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Cruzeiro",
+      "Santos",
+      "Monaco",
+      "Grêmio",
+      "Atlético Mineiro"
+    ]
+  },
+  {
+    "id": 407,
+    "name": "Fagner",
+    "birthdate": "1989-06-11",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "PSV Eindhoven",
+      "Vasco da Gama",
+      "Wolfsburg",
+      "Vitória"
+    ]
+  },
+  {
+    "id": 408,
+    "name": "Dudu",
+    "birthdate": "1992-01-07",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Dynamo Kyiv",
+      "Grêmio",
+      "Al-Duhail"
+    ]
+  },
+  {
+    "id": 409,
+    "name": "Gabriel Menino",
+    "birthdate": "2000-09-29",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": []
+  },
+  {
+    "id": 410,
+    "name": "Beltran",
+    "birthdate": "2001-04-28",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "River Plate"
+    ]
+  },
+  {
+    "id": 412,
+    "name": "Abel Ferreira",
+    "birthdate": "1978-12-22",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Braga",
+      "PAOK"
+    ]
+  },
+  {
+    "id": 413,
+    "name": "Wellington Rato",
+    "birthdate": "1992-03-19",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Goianiense",
+      "Ferroviaria",
+      "Ponte Preta",
+      "CRB",
+      "Sampaio Corrêa"
+    ]
+  },
+  {
+    "id": 414,
+    "name": "Luciano",
+    "birthdate": "1993-05-18",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Leganés",
+      "Fluminense",
+      "Parana",
+      "Avaí",
+      "Corinthians",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 415,
+    "name": "Rafael",
+    "birthdate": "1989-07-09",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Atlético Mineiro"
+    ]
+  },
+  {
+    "id": 416,
+    "name": "Marcos Rocha",
+    "birthdate": "1988-12-11",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Mineiro",
+      "Ponte Preta"
+    ]
+  },
+  {
+    "id": 417,
+    "name": "Zubeldía",
+    "birthdate": "1981-04-13",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Racing Club",
+      "Internacional"
+    ]
+  },
+  {
+    "id": 418,
+    "name": "Germán Cano",
+    "birthdate": "1988-01-02",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Lanús",
+      "Nacional",
+      "Deportivo Pereira",
+      "Pachuca",
+      "Coloméx",
+      "Chácaras",
+      "Indep. Medellín",
+      "Vasco da Gama"
+    ]
+  },
+  {
+    "id": 419,
+    "name": "Felipe Melo",
+    "birthdate": "1983-06-26",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Cruzeiro",
+      "Grêmio",
+      "Mallorca",
+      "Racing Santander",
+      "Almería",
+      "Fiorentina",
+      "Juventus",
+      "Galatasaray",
+      "Inter Milan",
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 420,
+    "name": "Ganso",
+    "birthdate": "1989-10-12",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "São Paulo",
+      "Sevilla",
+      "Amiens"
+    ]
+  },
+  {
+    "id": 421,
+    "name": "Keno",
+    "birthdate": "1989-09-10",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santa Cruz",
+      "Atlas",
+      "Puebla",
+      "Palmeiras",
+      "Pyramids",
+      "Atlético Mineiro"
+    ]
+  },
+  {
+    "id": 422,
+    "name": "Diniz",
+    "birthdate": "1974-03-11",
+    "club": "Cruzeiro",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Atlético Paranaense",
+      "Guarani",
+      "Santos",
+      "Fluminense",
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 423,
+    "name": "Jhon Arías",
+    "birthdate": "1997-09-21",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "América de Cali",
+      "Patrícios",
+      "Santa Fe",
+      "Independiente"
+    ]
+  },
+  {
+    "id": 424,
+    "name": "André",
+    "birthdate": "2001-07-16",
+    "club": "Wolverhampton",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 425,
+    "name": "Líma",
+    "birthdate": "1999-12-18",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": []
+  },
+  {
+    "id": 426,
+    "name": "Martinelli",
+    "birthdate": "2001-07-25",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": []
+  },
+  {
+    "id": 427,
+    "name": "Fábio",
+    "birthdate": "1980-09-30",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Cruzeiro"
+    ]
+  },
+  {
+    "id": 428,
+    "name": "Renato Augusto",
+    "birthdate": "1988-02-08",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Bayer Leverkusen",
+      "Corinthians",
+      "Beijing Guoan"
+    ]
+  },
+  {
+    "id": 429,
+    "name": "Dida",
+    "birthdate": "1973-10-07",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vitória",
+      "Cruzeiro",
+      "Lugano",
+      "Corinthians",
+      "Milan",
+      "Internacional",
+      "Portuguesa",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 430,
+    "name": "Jerome Boateng",
+    "birthdate": "1988-09-03",
+    "club": "LASK",
+    "league": "Austrian Bundesliga",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Hertha BSC",
+      "Hamburger SV",
+      "Manchester City",
+      "Bayern Munich",
+      "Lyon",
+      "Salernitana"
+    ]
+  },
+  {
+    "id": 432,
+    "name": "Paulista",
+    "birthdate": "1986-06-15",
+    "club": "Vasco da Gama",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Ituano",
+      "Santos",
+      "Arsenal",
+      "Villarreal"
+    ]
+  },
+  {
+    "id": 433,
+    "name": "Arrascaeta",
+    "birthdate": "1994-06-01",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Defensor Sporting",
+      "Cruzeiro"
+    ]
+  },
+  {
+    "id": 434,
+    "name": "Soteldo",
+    "birthdate": "1997-06-28",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Venezuela",
+    "past_clubs": [
+      "Zamora",
+      "Huachipato",
+      "Universidad de Chile",
+      "Santos",
+      "Toronto FC",
+      "Tigres UANL"
+    ]
+  },
+  {
+    "id": 435,
+    "name": "Villasanti",
+    "birthdate": "1998-06-05",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Paraguay",
+    "past_clubs": [
+      "Cerro Porteno",
+      "Guaraní"
+    ]
+  },
+  {
+    "id": 436,
+    "name": "Cristaldo",
+    "birthdate": "1989-03-15",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Vela",
+      "Arsenal de Sarandí",
+      "Metalist Kharkiv",
+      "Bologna",
+      "Palmeiras",
+      "Cruz Azul",
+      "Rayo Vallecano",
+      "Boca Juniors",
+      "Monterrey",
+      "Huracán"
+    ]
+  },
+  {
+    "id": 437,
+    "name": "Renato Portaluppi",
+    "birthdate": "1962-09-09",
+    "club": "Grêmio",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Flamengo",
+      "Athlético Paranaense"
+    ]
+  },
+  {
+    "id": 438,
+    "name": "Pepê",
+    "birthdate": "1997-02-24",
+    "club": "Porto",
+    "league": "Primeira Liga",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Foz do Iguaçu",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 439,
+    "name": "Vitão",
+    "birthdate": "1993-12-12",
+    "club": "Internacional",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras",
+      "Botafogo",
+      "Santos",
+      "Atlético GO"
+    ]
+  },
+  {
+    "id": 440,
+    "name": "Alan Patrick",
+    "birthdate": "1991-05-13",
+    "club": "Internacional",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Internacional",
+      "Shakhtar Donetsk",
+      "Flamengo",
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 441,
+    "name": "Roger Machado",
+    "birthdate": "1975-04-25",
+    "club": "Internacional",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Juventude",
+      "Novo Hamburgo",
+      "Grêmio",
+      "Atlético Mineiro",
+      "Palmeiras",
+      "Bahia",
+      "Fluminense",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 442,
+    "name": "Wanderson",
+    "birthdate": "1994-10-07",
+    "club": "Internacional",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Belenenses",
+      "Liefering",
+      "Red Bull Salzburg",
+      "LASK",
+      "Krasnodar"
+    ]
+  },
+  {
+    "id": 443,
+    "name": "Arana",
+    "birthdate": "1997-04-14",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Corinthians",
+      "Sevilla",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 444,
+    "name": "Deyverson",
+    "birthdate": "1991-05-08",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Belenenses",
+      "Köln",
+      "Levante",
+      "Alavés",
+      "Palmeiras",
+      "Getafe",
+      "Cuiabá"
+    ]
+  },
+  {
+    "id": 445,
+    "name": "Gabriel",
+    "birthdate": "1992-11-18",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Internacional",
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 446,
+    "name": "Tiquinho Soares",
+    "birthdate": "1991-01-17",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Nacional-MG",
+      "Sousa EC",
+      "America-RN",
+      "Bot-PB",
+      "Oeste",
+      "Nacional",
+      "Vitória de Guimarães",
+      "Porto",
+      "Tianjin Teda",
+      "Guangzhou",
+      "Olympiacos"
+    ]
+  },
+  {
+    "id": 447,
+    "name": "Artur Jorge",
+    "birthdate": "1972-02-17",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Braga"
+    ]
+  },
+  {
+    "id": 448,
+    "name": "Marlon Freitas",
+    "birthdate": "1995-05-19",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Ceará",
+      "Boavista",
+      "Criciúma",
+      "Boa",
+      "Atlético Goianiense"
+    ]
+  },
+  {
+    "id": 449,
+    "name": "John",
+    "birthdate": "1996-03-12",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Santos"
+    ]
+  },
+  {
+    "id": 450,
+    "name": "Cuiabano",
+    "birthdate": "2000-05-14",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 451,
+    "name": "Igor Jesus",
+    "birthdate": "2001-02-02",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Shabab Al-Ahli"
+    ]
+  },
+  {
+    "id": 452,
+    "name": "Rafael",
+    "birthdate": "1990-07-09",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Manchester United",
+      "Lyon",
+      "Istanbul Basaksehir"
+    ]
+  },
+  {
+    "id": 453,
+    "name": "Jefferson",
+    "birthdate": "1983-01-02",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Botafogo",
+      "Trabzonspor"
+    ]
+  },
+  {
+    "id": 454,
+    "name": "Luiz Henrique",
+    "birthdate": "2001-01-14",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Real Betis"
+    ]
+  },
+  {
+    "id": 455,
+    "name": "Alexandre Pato",
+    "birthdate": "1989-09-02",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Milan",
+      "Corinthians",
+      "São Paulo",
+      "Chelsea",
+      "Villarreal",
+      "Tianjin Tianhai",
+      "Orlando City"
+    ]
+  },
+  {
+    "id": 456,
+    "name": "Luiz Adriano",
+    "birthdate": "1987-04-12",
+    "club": "Internacional",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Shakhtar Donetsk",
+      "Milan",
+      "Spartak Moscow",
+      "Palmeiras",
+      "Antalyaspor"
+    ]
+  },
+  {
+    "id": 457,
+    "name": "Nino",
+    "birthdate": "1997-04-10",
+    "club": "Zenit",
+    "league": "Russian Premier League",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Criciúma",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 458,
+    "name": "Caio Paulista",
+    "birthdate": "1998-06-09",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Avai",
+      "Fluminense",
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 459,
+    "name": "Igor Coronado",
+    "birthdate": "1992-08-03",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Milton Keynes Dons",
+      "Banbury United",
+      "Leatherhead",
+      "Chesham United",
+      "Green Harefield",
+      "Floriana",
+      "Trapani",
+      "Palermo",
+      "Al-Sharjah",
+      "Al-Ittihad"
+    ]
+  },
+  {
+    "id": 460,
+    "name": "William",
+    "birthdate": "1995-05-03",
+    "club": "Cruzeiro",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Wolfsburg",
+      "Schalke 04"
+    ]
+  },
+  {
+    "id": 461,
+    "name": "Alex Telles",
+    "birthdate": "1992-12-15",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Juventude",
+      "Grêmio",
+      "Galatasaray",
+      "Inter Milan",
+      "Porto",
+      "Manchester United",
+      "Sevilla",
+      "Al-Nassr"
+    ]
+  },
+  {
+    "id": 462,
+    "name": "Zé Rafael",
+    "birthdate": "1993-06-16",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Coritiba",
+      "Figueirense",
+      "Bahia"
+    ]
+  },
+  {
+    "id": 463,
+    "name": "Richard Ríos",
+    "birthdate": "2000-03-14",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Guarani"
+    ]
+  },
+  {
+    "id": 464,
+    "name": "Pérez",
+    "birthdate": "1996-03-01",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Newell's Old Boys"
+    ]
+  },
+  {
+    "id": 465,
+    "name": "Barboza",
+    "birthdate": "1995-12-29",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Defensa y Justicia",
+      "Indep. del Valle",
+      "River Plate",
+      "Rosario Central",
+      "Atlético MG"
+    ]
+  },
+  {
+    "id": 466,
+    "name": "Luiz Araújo",
+    "birthdate": "1996-06-02",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Novorizontino",
+      "Mirassol",
+      "Lille",
+      "Atlanta United"
+    ]
+  },
+  {
+    "id": 467,
+    "name": "Wesley",
+    "birthdate": "2000-03-06",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 468,
+    "name": "Yuri Alberto",
+    "birthdate": "2001-03-18",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Internacional",
+      "Zenit"
+    ]
+  },
+  {
+    "id": 469,
+    "name": "Matheuzinho",
+    "birthdate": "2000-09-18",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Londrina",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 470,
+    "name": "Raniele",
+    "birthdate": "1996-09-18",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Avai",
+      "Botafogo-SP",
+      "Cuiabá"
+    ]
+  },
+  {
+    "id": 471,
+    "name": "Rômulo",
+    "birthdate": "1995-12-02",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Novorizontino",
+      "Avaí",
+      "Ferroviaria",
+      "Cruzeiro"
+    ]
+  },
+  {
+    "id": 472,
+    "name": "Veiga",
+    "birthdate": "1995-06-29",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Coritiba",
+      "Athlético Paranaense"
+    ]
+  },
+  {
+    "id": 473,
+    "name": "Piquerez",
+    "birthdate": "1998-08-24",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Defensor Sporting",
+      "Peñarol",
+      "Montevideo Wanderers"
+    ]
+  },
+  {
+    "id": 474,
+    "name": "Murilo",
+    "birthdate": "1997-03-27",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Lokomotiv Moscow"
+    ]
+  },
+  {
+    "id": 475,
+    "name": "Dorival Júnior",
+    "birthdate": "1962-04-25",
+    "club": "Brazil",
+    "league": "Seleção",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cerezo Osaka",
+      "Athlético Paranaense",
+      "Flamengo",
+      "Santos",
+      "São Paulo",
+      "Internacional",
+      "Vasco",
+      "Fluminense",
+      "Palmeiras",
+      "Atlético MG",
+      "Coritiba"
+    ]
+  },
+  {
+    "id": 476,
+    "name": "Luis Guilherme",
+    "birthdate": "2006-04-07",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": []
+  },
+  {
+    "id": 478,
+    "name": "Ayrton Lucas",
+    "birthdate": "1997-06-19",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Spartak Moscow"
+    ]
+  },
+  {
+    "id": 480,
+    "name": "Fabrizio Peralta",
+    "birthdate": "2000-12-10",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Paraguay",
+    "past_clubs": [
+      "Cerro Porteño"
+    ]
+  },
+  {
+    "id": 481,
+    "name": "Varela",
+    "birthdate": "1993-03-24",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Peñarol",
+      "Manchester United",
+      "Real Madrid Castilla",
+      "Eintracht Frankfurt",
+      "Copenhagen"
+    ]
+  },
+  {
+    "id": 482,
+    "name": "Carlinhos",
+    "birthdate": "1996-08-28",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Nova Iguaçu",
+      "Santos",
+      "Defensa Y Justicia",
+      "Botafogo-SP",
+      "América RN",
+      "Guarani",
+      "Standard Liège"
+    ]
+  },
+  {
+    "id": 483,
+    "name": "Filipe Luís",
+    "birthdate": "1985-08-09",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Figueirense",
+      "Ajax",
+      "Real Madrid B",
+      "Deportivo La Coruña",
+      "Atlético Madrid",
+      "Chelsea",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 484,
+    "name": "Tite",
+    "birthdate": "1961-05-25",
+    "club": "Flamengo",
+    "league": "Brasileirão Série A",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Brazil",
+      "Grêmio",
+      "Corinthians",
+      "Atlético MG",
+      "Palmeiras",
+      "Al Ain",
+      "Al-Wahda",
+      "Internacional"
+    ]
+  },
+  {
+    "id": 485,
+    "name": "Wellington",
+    "birthdate": "1991-01-28",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Internacional",
+      "Vasco",
+      "Ponte Preta",
+      "Chapecoense",
+      "Athletico-PR",
+      "Miami FC",
+      "Fluminense",
+      "Grêmio",
+      "Japan"
+    ]
+  },
+  {
+    "id": 486,
+    "name": "Calleri",
+    "birthdate": "1993-09-23",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "All Boys",
+      "Boca Juniors",
+      "West Ham",
+      "Las Palmas",
+      "Alavés",
+      "Espanyol",
+      "Osasuna"
+    ]
+  },
+  {
+    "id": 487,
+    "name": "Alisson",
+    "birthdate": "1993-06-06",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Grêmio",
+      "Al-Jazira"
+    ]
+  },
+  {
+    "id": 488,
+    "name": "Lucas Moura",
+    "birthdate": "1992-08-13",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Paris Saint-Germain",
+      "Tottenham"
+    ]
+  },
+  {
+    "id": 489,
+    "name": "Rafaíça",
+    "birthdate": "1985-09-29",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Juventude",
+      "Schalke 04",
+      "Bayern Munich",
+      "Flamengo",
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 490,
+    "name": "Michel Araújo",
+    "birthdate": "1996-12-13",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Londrina",
+      "Avai",
+      "Fluminense"
+    ]
+  },
+  {
+    "id": 491,
+    "name": "Jandrei",
+    "birthdate": "1993-03-01",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Tubarão",
+      "Chapecoense",
+      "Genoa",
+      "Santos"
+    ]
+  },
+  {
+    "id": 492,
+    "name": "Richard Rios",
+    "birthdate": "2000-04-02",
+    "club": "Palmeiras",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Flamengo",
+      "Guarani"
+    ]
+  },
+  {
+    "id": 493,
+    "name": "Juan",
+    "birthdate": "1979-02-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Bayer Leverkusen",
+      "Roma",
+      "Internacional"
+    ]
+  },
+  {
+    "id": 494,
+    "name": "Diego Alves",
+    "birthdate": "1985-06-24",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Mineiro",
+      "Almería",
+      "Valencia",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 495,
+    "name": "Diego Cavalieri",
+    "birthdate": "1982-12-01",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Goalkeeper",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras",
+      "Liverpool",
+      "Cesena",
+      "Fluminense",
+      "Crystal Palace",
+      "Botafogo"
+    ]
+  },
+  {
+    "id": 496,
+    "name": "Jardine",
+    "birthdate": "1974-01-17",
+    "club": "Brazil Olympic",
+    "league": "Seleção",
+    "position": "Manager",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo"
+    ]
+  },
+  {
+    "id": 497,
+    "name": "Teixeira",
+    "birthdate": "1990-01-05",
+    "club": "Botafogo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Vasco da Gama",
+      "Shakhtar Donetsk",
+      "Jiangsu Suning"
+    ]
+  },
+  {
+    "id": 498,
+    "name": "Diego Ribas",
+    "birthdate": "1985-02-28",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Santos",
+      "Porto",
+      "Werder Bremen",
+      "Juventus",
+      "Wolfsburg",
+      "Atlético Madrid",
+      "Fenerbahçe",
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 500,
+    "name": "David De Gea",
+    "birthdate": "1990-11-07",
+    "club": "Fiorentina",
+    "league": "Serie A",
+    "position": "Goalkeeper",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Atlético Madrid",
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 501,
+    "name": "Marc-André ter Stegen",
+    "birthdate": "1992-04-30",
+    "club": "Barcelona",
+    "league": "La Liga",
+    "position": "Goalkeeper",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Borussia Mönchengladbach"
+    ]
+  },
+  {
+    "id": 502,
+    "name": "Mike Maignan",
+    "birthdate": "1995-07-03",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Goalkeeper",
+    "nationality": "France",
+    "past_clubs": [
+      "Paris Saint-Germain",
+      "Lille"
+    ]
+  },
+  {
+    "id": 503,
+    "name": "Diogo Leite",
+    "birthdate": "1999-01-23",
+    "club": "Union Berlin",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Porto",
+      "Braga"
+    ]
+  },
+  {
+    "id": 506,
+    "name": "Diogo Costa",
+    "birthdate": "1999-09-19",
+    "club": "Porto",
+    "league": "Primeira Liga",
+    "position": "Goalkeeper",
+    "nationality": "Portugal",
+    "past_clubs": []
+  },
+  {
+    "id": 507,
+    "name": "André Onana",
+    "birthdate": "1996-04-02",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Cameroon",
+    "past_clubs": [
+      "Barcelona B",
+      "Ajax",
+      "Inter Milan"
+    ]
+  },
+  {
+    "id": 508,
+    "name": "Yassine Bounou",
+    "birthdate": "1991-04-05",
+    "club": "Al-Hilal",
+    "league": "Saudi Pro League",
+    "position": "Goalkeeper",
+    "nationality": "Morocco",
+    "past_clubs": [
+      "Wydad Casablanca",
+      "Atlético Madrid",
+      "Zaragoza",
+      "Girona",
+      "Sevilla"
+    ]
+  },
+  {
+    "id": 510,
+    "name": "David Raya",
+    "birthdate": "1995-09-15",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Blackburn Rovers",
+      "Brentford"
+    ]
+  },
+  {
+    "id": 511,
+    "name": "Jordan Pickford",
+    "birthdate": "1994-03-07",
+    "club": "Everton",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "England",
+    "past_clubs": [
+      "Sunderland",
+      "Darlington",
+      "Burton Albion",
+      "Carlisle United",
+      "Bradford City",
+      "Preston North End"
+    ]
+  },
+  {
+    "id": 512,
+    "name": "João Pedro",
+    "birthdate": "2001-09-26",
+    "club": "Brighton & Hove Albion",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Fluminense",
+      "Watford"
+    ]
+  },
+  {
+    "id": 513,
+    "name": "Estêvão Willian",
+    "birthdate": "2007-04-24",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Palmeiras"
+    ]
+  },
+  {
+    "id": 514,
+    "name": "Savinho",
+    "birthdate": "2004-04-01",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Atlético Mineiro",
+      "PSV Eindhoven",
+      "Troyes",
+      "Girona"
+    ]
+  },
+  {
+    "id": 515,
+    "name": "Yan Couto",
+    "birthdate": "2002-06-03",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Coritiba",
+      "Manchester City",
+      "Girona",
+      "Braga"
+    ]
+  },
+  {
+    "id": 516,
+    "name": "Nico Williams",
+    "birthdate": "2002-07-12",
+    "club": "Athletic Bilbao",
+    "league": "La Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": []
+  },
+  {
+    "id": 517,
+    "name": "João Neves",
+    "birthdate": "2004-09-27",
+    "club": "Paris Saint-Germain",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica"
+    ]
+  },
+  {
+    "id": 518,
+    "name": "Antonio Nusa",
+    "birthdate": "2005-04-17",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Stabæk",
+      "Club Brugge"
+    ]
+  },
+  {
+    "id": 519,
+    "name": "Khvicha Kvaratskhelia",
+    "birthdate": "2001-02-12",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Georgia",
+    "past_clubs": [
+      "Dinamo Tbilisi",
+      "Rustavi",
+      "Lokomotiv Moscow",
+      "Rubin Kazan",
+      "Dinamo Batumi"
+    ]
+  },
+  {
+    "id": 520,
+    "name": "Xavi Simons",
+    "birthdate": "2003-04-21",
+    "club": "RB Leipzig",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Barcelona",
+      "Paris Saint-Germain",
+      "PSV Eindhoven"
+    ]
+  },
+  {
+    "id": 521,
+    "name": "Adam Hlozek",
+    "birthdate": "2002-07-25",
+    "club": "Bayer Leverkusen",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "Czech Republic",
+    "past_clubs": [
+      "Sparta Prague"
+    ]
+  },
+  {
+    "id": 522,
+    "name": "Kepa Arrizabalaga",
+    "birthdate": "1994-10-03",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Goalkeeper",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Athletic Bilbao",
+      "Chelsea",
+      "Napoli"
+    ]
+  },
+  {
+    "id": 523,
+    "name": "Unai Simón",
+    "birthdate": "1997-06-11",
+    "club": "Athletic Bilbao",
+    "league": "La Liga",
+    "position": "Goalkeeper",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Basconia",
+      "Bilbao Athletic"
+    ]
+  },
+  {
+    "id": 524,
+    "name": "Leandro Trossard",
+    "birthdate": "1994-12-04",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Genk",
+      "Lommel",
+      "Brighton & Hove Albion"
+    ]
+  },
+  {
+    "id": 527,
+    "name": "Emile Smith Rowe",
+    "birthdate": "2000-07-28",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "RB Leipzig",
+      "Huddersfield Town"
+    ]
+  },
+  {
+    "id": 529,
+    "name": "Mikel Merino",
+    "birthdate": "1996-06-22",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Osasuna",
+      "Borussia Dortmund",
+      "Newcastle United",
+      "Real Sociedad"
+    ]
+  },
+  {
+    "id": 531,
+    "name": "Oleksandr Zinchenko",
+    "birthdate": "1996-12-15",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Ukraine",
+    "past_clubs": [
+      "Shakhtar Donetsk",
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 533,
+    "name": "Jurrien Timber",
+    "birthdate": "2001-06-17",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax"
+    ]
+  },
+  {
+    "id": 535,
+    "name": "Benjamin White",
+    "birthdate": "1997-10-08",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "England",
+    "past_clubs": [
+      "Brighton & Hove Albion",
+      "Leeds United",
+      "Peterborough United",
+      "Newport County"
+    ]
+  },
+  {
+    "id": 538,
+    "name": "Romeo Lavia",
+    "birthdate": "2004-01-06",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Anderlecht",
+      "Manchester City",
+      "Southampton"
+    ]
+  },
+  {
+    "id": 539,
+    "name": "Mykhailo Mudryk",
+    "birthdate": "2001-01-05",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Ukraine",
+    "past_clubs": [
+      "Metalist Kharkiv",
+      "Dnipro-1",
+      "Shakhtar Donetsk"
+    ]
+  },
+  {
+    "id": 540,
+    "name": "Nicolas Jackson",
+    "birthdate": "2001-06-20",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Senegal",
+    "past_clubs": [
+      "Casa Sports",
+      "Villarreal"
+    ]
+  },
+  {
+    "id": 543,
+    "name": "João Gomes",
+    "birthdate": "2001-02-20",
+    "club": "Wolverhampton Wanderers",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo"
+    ]
+  },
+  {
+    "id": 545,
+    "name": "Sepp van den Berg",
+    "birthdate": "2001-12-20",
+    "club": "Brentford",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "PEC Zwolle",
+      "Liverpool",
+      "Preston North End",
+      "Schalke 04",
+      "Mainz 05"
+    ]
+  },
+  {
+    "id": 546,
+    "name": "Kiernan Dewsbury-Hall",
+    "birthdate": "1998-09-06",
+    "club": "Chelsea",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Leicester City",
+      "Blackpool",
+      "Luton Town"
+    ]
+  },
+  {
+    "id": 547,
+    "name": "Destiny Udogie",
+    "birthdate": "2002-11-28",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Hellas Verona",
+      "Udinese"
+    ]
+  },
+  {
+    "id": 548,
+    "name": "Miguel Almirón",
+    "birthdate": "1994-02-10",
+    "club": "Newcastle United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Paraguay",
+    "past_clubs": [
+      "Cerro Porteño",
+      "Lanús",
+      "Atlanta United"
+    ]
+  },
+  {
+    "id": 549,
+    "name": "Oscar Bobb",
+    "birthdate": "2003-07-12",
+    "club": "Manchester City",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Valerenga"
+    ]
+  },
+  {
+    "id": 559,
+    "name": "Federico Chiesa",
+    "birthdate": "1997-10-25",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Fiorentina",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 560,
+    "name": "Ryan Gravenberch",
+    "birthdate": "2002-05-16",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Ajax",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 563,
+    "name": "Ibrahima Konaté",
+    "birthdate": "1999-05-25",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Sochaux",
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 564,
+    "name": "Dejan Kulusevski",
+    "birthdate": "2000-04-25",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Brommapojkarna",
+      "Atalanta",
+      "Parma",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 566,
+    "name": "Rasmus Højlund",
+    "birthdate": "2003-02-04",
+    "club": "Manchester United",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Denmark",
+    "past_clubs": [
+      "FC Copenhagen",
+      "Sturm Graz",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 567,
+    "name": "Gustavo Scarpa",
+    "birthdate": "1994-01-05",
+    "club": "Atlético Mineiro",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Desportivo Brasil",
+      "Red Bull Brasil",
+      "Fluminense",
+      "Palmeiras",
+      "Nottingham Forest",
+      "Olympiacos"
+    ]
+  },
+  {
+    "id": 568,
+    "name": "Alisson Euler",
+    "birthdate": "1993-06-19",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Cruzeiro",
+      "Internacional",
+      "Grêmio",
+      "Atlético Mineiro",
+      "Al-Hazem"
+    ]
+  },
+  {
+    "id": 570,
+    "name": "Alan Franco",
+    "birthdate": "1997-02-11",
+    "club": "São Paulo",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Independiente",
+      "Atlético Mineiro",
+      "Atlanta United"
+    ]
+  },
+  {
+    "id": 572,
+    "name": "Diogo Jota",
+    "birthdate": "1996-12-04",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Paços de Ferreira",
+      "Atlético Madrid",
+      "Porto",
+      "Wolverhampton Wanderers"
+    ]
+  },
+  {
+    "id": 575,
+    "name": "Harvey Elliott",
+    "birthdate": "2003-04-04",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Fulham",
+      "Blackburn Rovers"
+    ]
+  },
+  {
+    "id": 576,
+    "name": "Cody Gakpo",
+    "birthdate": "1999-05-07",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "PSV Eindhoven"
+    ]
+  },
+  {
+    "id": 580,
+    "name": "Manor Solomon",
+    "birthdate": "1999-07-24",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Israel",
+    "past_clubs": [
+      "Maccabi Petah Tikva",
+      "Shakhtar Donetsk",
+      "Fulham"
+    ]
+  },
+  {
+    "id": 581,
+    "name": "Yves Bissouma",
+    "birthdate": "1996-08-30",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Mali",
+    "past_clubs": [
+      "Lille",
+      "Brighton & Hove Albion"
+    ]
+  },
+  {
+    "id": 583,
+    "name": "Brennan Johnson",
+    "birthdate": "2001-05-23",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Wales",
+    "past_clubs": [
+      "Nottingham Forest",
+      "Lincoln City"
+    ]
+  },
+  {
+    "id": 584,
+    "name": "Pape Matar Sarr",
+    "birthdate": "2002-09-14",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Senegal",
+    "past_clubs": [
+      "Génération Foot",
+      "Metz"
+    ]
+  },
+  {
+    "id": 585,
+    "name": "Rodrigo Bentancur",
+    "birthdate": "1997-06-25",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Uruguay",
+    "past_clubs": [
+      "Boca Juniors",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 586,
+    "name": "Micky van de Ven",
+    "birthdate": "2001-04-19",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Volendam",
+      "Wolfsburg"
+    ]
+  },
+  {
+    "id": 587,
+    "name": "Guglielmo Vicario",
+    "birthdate": "1996-10-07",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Goalkeeper",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Udinese",
+      "Venezia",
+      "Perugia",
+      "Cagliari",
+      "Empoli"
+    ]
+  },
+  {
+    "id": 588,
+    "name": "Radu Dragusin",
+    "birthdate": "2002-02-03",
+    "club": "Tottenham Hotspur",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Romania",
+    "past_clubs": [
+      "Juventus",
+      "Sampdoria",
+      "Salernitana",
+      "Genoa"
+    ]
+  },
+  {
+    "id": 589,
+    "name": "Jhon Durán",
+    "birthdate": "2003-12-13",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Envigado",
+      "Chicago Fire"
+    ]
+  },
+  {
+    "id": 590,
+    "name": "Jacob Ramsey",
+    "birthdate": "2001-05-28",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": []
+  },
+  {
+    "id": 591,
+    "name": "Emiliano Buendía",
+    "birthdate": "1996-12-25",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Getafe",
+      "Cultural Leonesa",
+      "Norwich City"
+    ]
+  },
+  {
+    "id": 592,
+    "name": "Leon Bailey",
+    "birthdate": "1997-08-09",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Forward",
+    "nationality": "Jamaica",
+    "past_clubs": [
+      "AS Trencin",
+      "Genk",
+      "Bayer Leverkusen"
+    ]
+  },
+  {
+    "id": 593,
+    "name": "Amadou Onana",
+    "birthdate": "2001-08-16",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Hoffenheim",
+      "Hamburg",
+      "Lille",
+      "Everton"
+    ]
+  },
+  {
+    "id": 594,
+    "name": "Ross Barkley",
+    "birthdate": "1993-12-05",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Everton",
+      "Chelsea",
+      "Aston Villa",
+      "Nice",
+      "Luton Town"
+    ]
+  },
+  {
+    "id": 596,
+    "name": "Moussa Diaby",
+    "birthdate": "1999-07-07",
+    "club": "Al-Ittihad",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Paris Saint-Germain",
+      "Crotone",
+      "Bayer Leverkusen",
+      "Aston Villa"
+    ]
+  },
+  {
+    "id": 597,
+    "name": "Youri Tielemans",
+    "birthdate": "1997-05-07",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Anderlecht",
+      "Monaco",
+      "Leicester City"
+    ]
+  },
+  {
+    "id": 598,
+    "name": "Enzo Barrenechea",
+    "birthdate": "2001-05-11",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Newell's Old Boys",
+      "Sion",
+      "Juventus",
+      "Frosinone"
+    ]
+  },
+  {
+    "id": 599,
+    "name": "Ian Maatsen",
+    "birthdate": "2002-03-10",
+    "club": "Aston Villa",
+    "league": "Premier League",
+    "position": "Defender",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "Chelsea",
+      "Charlton Athletic",
+      "Coventry City",
+      "Burnley",
+      "Borussia Dortmund"
+    ]
+  },
+  {
+    "id": 600,
+    "name": "Samuel Omorodion",
+    "birthdate": "2004-04-23",
+    "club": "Porto",
+    "league": "Primeira Liga",
+    "position": "Forward",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Granada",
+      "Atlético Madrid",
+      "Alavés"
+    ]
+  },
+  {
+    "id": 601,
+    "name": "Brian Brobbey",
+    "birthdate": "2002-02-01",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "RB Leipzig"
+    ]
+  },
+  {
+    "id": 602,
+    "name": "Kenneth Taylor",
+    "birthdate": "2002-05-16",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": []
+  },
+  {
+    "id": 603,
+    "name": "Carlos Forbs",
+    "birthdate": "2004-02-23",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 604,
+    "name": "Daniele Rugani",
+    "birthdate": "1994-07-29",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Empoli",
+      "Juventus",
+      "Rennes",
+      "Cagliari"
+    ]
+  },
+  {
+    "id": 605,
+    "name": "Josip Sutalo",
+    "birthdate": "2000-02-28",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Defender",
+    "nationality": "Croatia",
+    "past_clubs": [
+      "Dinamo Zagreb",
+      "Istra 1961"
+    ]
+  },
+  {
+    "id": 606,
+    "name": "Jordan Henderson",
+    "birthdate": "1990-06-17",
+    "club": "Ajax",
+    "league": "Eredivisie",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Sunderland",
+      "Coventry City",
+      "Liverpool",
+      "Al-Ettifaq"
+    ]
+  },
+  {
+    "id": 607,
+    "name": "Arda Güler",
+    "birthdate": "2005-02-25",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Turkey",
+    "past_clubs": [
+      "Genclerbirligi",
+      "Fenerbahçe"
+    ]
+  },
+  {
+    "id": 611,
+    "name": "Lucas Paquetá",
+    "birthdate": "1997-08-27",
+    "club": "West Ham United",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Flamengo",
+      "Lyon"
+    ]
+  },
+  {
+    "id": 612,
+    "name": "Joao Palhinha",
+    "birthdate": "1995-07-09",
+    "club": "Bayern Munich",
+    "league": "Bundesliga",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Belenenses",
+      "Moreirense",
+      "Braga",
+      "Fulham"
+    ]
+  },
+  {
+    "id": 613,
+    "name": "Francisco Conceicao",
+    "birthdate": "2002-12-14",
+    "club": "Porto",
+    "league": "Primeira Liga",
+    "position": "Forward",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Ajax"
+    ]
+  },
+  {
+    "id": 614,
+    "name": "André Gomes",
+    "birthdate": "1993-07-30",
+    "club": "Lille",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Benfica",
+      "Valencia",
+      "Barcelona",
+      "Everton"
+    ]
+  },
+  {
+    "id": 615,
+    "name": "James Rodríguez",
+    "birthdate": "1991-07-12",
+    "club": "Club León",
+    "league": "Liga MX",
+    "position": "Midfielder",
+    "nationality": "Colombia",
+    "past_clubs": [
+      "Envigado",
+      "Banfield",
+      "Porto",
+      "Monaco",
+      "Real Madrid",
+      "Bayern Munich",
+      "Everton",
+      "Al-Rayyan",
+      "Olympiacos",
+      "São Paulo",
+      "Rayo Vallecano"
+    ]
+  },
+  {
+    "id": 616,
+    "name": "Amin Younes",
+    "birthdate": "1993-08-06",
+    "club": "Free Agent",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Borussia Mönchengladbach",
+      "Kaiserslautern",
+      "Ajax",
+      "Napoli",
+      "Eintracht Frankfurt",
+      "Al-Ettifaq",
+      "Utrecht"
+    ]
+  },
+  {
+    "id": 617,
+    "name": "Memphis Depay",
+    "birthdate": "1994-02-13",
+    "club": "Corinthians",
+    "league": "Brasileirão Série A",
+    "position": "Forward",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "PSV Eindhoven",
+      "Manchester United",
+      "Lyon",
+      "Barcelona",
+      "Atlético Madrid"
+    ]
+  },
+  {
+    "id": 618,
+    "name": "Jamie Bynoe-Gittens",
+    "birthdate": "2004-08-08",
+    "club": "Borussia Dortmund",
+    "league": "Bundesliga",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Manchester City"
+    ]
+  },
+  {
+    "id": 619,
+    "name": "Vanderson",
+    "birthdate": "2001-06-21",
+    "club": "Monaco",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Grêmio"
+    ]
+  },
+  {
+    "id": 620,
+    "name": "Thilo Kehrer",
+    "birthdate": "1996-09-21",
+    "club": "Monaco",
+    "league": "Ligue 1",
+    "position": "Defender",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Schalke 04",
+      "Paris Saint-Germain",
+      "West Ham United"
+    ]
+  },
+  {
+    "id": 621,
+    "name": "Folarin Balogun",
+    "birthdate": "2001-07-03",
+    "club": "Monaco",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "United States",
+    "past_clubs": [
+      "Arsenal",
+      "Middlesbrough",
+      "Reims"
+    ]
+  },
+  {
+    "id": 622,
+    "name": "Denis Zakaria",
+    "birthdate": "1996-11-20",
+    "club": "Monaco",
+    "league": "Ligue 1",
+    "position": "Midfielder",
+    "nationality": "Switzerland",
+    "past_clubs": [
+      "Servette",
+      "Young Boys",
+      "Borussia Mönchengladbach",
+      "Juventus",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 623,
+    "name": "Breel Embolo",
+    "birthdate": "1997-02-14",
+    "club": "Monaco",
+    "league": "Ligue 1",
+    "position": "Forward",
+    "nationality": "Switzerland",
+    "past_clubs": [
+      "Basel",
+      "Schalke 04",
+      "Borussia Mönchengladbach"
+    ]
+  },
+  {
+    "id": 624,
+    "name": "Youssouf Fofana",
+    "birthdate": "1999-01-10",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "France",
+    "past_clubs": [
+      "Strasbourg",
+      "Monaco"
+    ]
+  },
+  {
+    "id": 626,
+    "name": "Thiago Silva",
+    "birthdate": "1984-09-22",
+    "club": "Fluminense",
+    "league": "Brasileirão Série A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "RS Futebol",
+      "Juventude",
+      "Fluminense",
+      "Milan",
+      "Paris Saint-Germain",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 628,
+    "name": "Brahim Díaz",
+    "birthdate": "1999-08-03",
+    "club": "Real Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "Morocco",
+    "past_clubs": [
+      "Manchester City",
+      "Milan"
+    ]
+  },
+  {
+    "id": 630,
+    "name": "Christian Pulisic",
+    "birthdate": "1998-09-18",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "United States",
+    "past_clubs": [
+      "Borussia Dortmund",
+      "Chelsea"
+    ]
+  },
+  {
+    "id": 631,
+    "name": "Timothy Weah",
+    "birthdate": "2000-02-22",
+    "club": "Juventus",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "United States",
+    "past_clubs": [
+      "Paris Saint-Germain",
+      "Celtic",
+      "Lille"
+    ]
+  },
+  {
+    "id": 632,
+    "name": "Ruben Loftus-Cheek",
+    "birthdate": "1996-01-23",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Crystal Palace",
+      "Fulham"
+    ]
+  },
+  {
+    "id": 633,
+    "name": "Davide Calabria",
+    "birthdate": "1996-12-06",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": []
+  },
+  {
+    "id": 634,
+    "name": "Matteo Gabbia",
+    "birthdate": "1999-10-21",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Lucchese",
+      "Villarreal"
+    ]
+  },
+  {
+    "id": 635,
+    "name": "Tammy Abraham",
+    "birthdate": "1997-10-02",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Bristol City",
+      "Swansea City",
+      "Aston Villa",
+      "Roma"
+    ]
+  },
+  {
+    "id": 637,
+    "name": "Zlatan Ibrahimovic",
+    "birthdate": "1981-10-03",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Forward",
+    "nationality": "Sweden",
+    "past_clubs": [
+      "Malmö FF",
+      "Ajax",
+      "Juventus",
+      "Inter Milan",
+      "Barcelona",
+      "Milan",
+      "Paris Saint-Germain",
+      "Manchester United",
+      "LA Galaxy"
+    ]
+  },
+  {
+    "id": 638,
+    "name": "Tijjani Reijnders",
+    "birthdate": "1998-07-28",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "PEC Zwolle",
+      "AZ Alkmaar"
+    ]
+  },
+  {
+    "id": 639,
+    "name": "Nicolò Barella",
+    "birthdate": "1997-02-07",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Cagliari"
+    ]
+  },
+  {
+    "id": 640,
+    "name": "Mehdi Taremi",
+    "birthdate": "1992-07-18",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Iran",
+    "past_clubs": [
+      "Iranjavan",
+      "Persepolis",
+      "Al-Gharafa",
+      "Rio Ave",
+      "Porto"
+    ]
+  },
+  {
+    "id": 641,
+    "name": "Benjamin Pavard",
+    "birthdate": "1996-03-28",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "France",
+    "past_clubs": [
+      "Lille",
+      "Stuttgart",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 642,
+    "name": "Marcus Thuram",
+    "birthdate": "1997-08-06",
+    "club": "Inter Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "France",
+    "past_clubs": [
+      "Sochaux",
+      "Guingamp",
+      "Borussia Mönchengladbach"
+    ]
+  },
+  {
+    "id": 643,
+    "name": "Giovanni Di Lorenzo",
+    "birthdate": "1993-08-04",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Lucchese",
+      "Matera",
+      "Reggina",
+      "Empoli"
+    ]
+  },
+  {
+    "id": 644,
+    "name": "Romelu Lukaku",
+    "birthdate": "1993-05-13",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Belgium",
+    "past_clubs": [
+      "Anderlecht",
+      "Chelsea",
+      "West Bromwich Albion",
+      "Everton",
+      "Manchester United",
+      "Inter Milan",
+      "Roma"
+    ]
+  },
+  {
+    "id": 645,
+    "name": "Scott McTominay",
+    "birthdate": "1996-12-08",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "Scotland",
+    "past_clubs": [
+      "Manchester United"
+    ]
+  },
+  {
+    "id": 646,
+    "name": "David Neres",
+    "birthdate": "1997-03-03",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "São Paulo",
+      "Ajax",
+      "Shakhtar Donetsk",
+      "Benfica"
+    ]
+  },
+  {
+    "id": 647,
+    "name": "Alessandro Buongiorno",
+    "birthdate": "1999-06-06",
+    "club": "Napoli",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Italy",
+    "past_clubs": [
+      "Torino",
+      "Carpi",
+      "Trapani"
+    ]
+  },
+  {
+    "id": 648,
+    "name": "Paulo Dybala",
+    "birthdate": "1993-11-15",
+    "club": "Roma",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Instituto",
+      "Palermo",
+      "Juventus"
+    ]
+  },
+  {
+    "id": 649,
+    "name": "Matias Soulé",
+    "birthdate": "2003-04-15",
+    "club": "Roma",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Argentina",
+    "past_clubs": [
+      "Vélez Sarsfield",
+      "Juventus",
+      "Frosinone"
+    ]
+  },
+  {
+    "id": 650,
+    "name": "Artem Dovbyk",
+    "birthdate": "1997-06-21",
+    "club": "Roma",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Ukraine",
+    "past_clubs": [
+      "Cherkaskyi Dnipro",
+      "Dnipro-1",
+      "Midtjylland",
+      "SønderjyskE",
+      "Girona"
+    ]
+  },
+  {
+    "id": 651,
+    "name": "Kevin-Prince Boateng",
+    "birthdate": "1987-03-06",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Ghana",
+    "past_clubs": [
+      "Hertha BSC",
+      "Tottenham Hotspur",
+      "Borussia Dortmund",
+      "Portsmouth",
+      "Milan",
+      "Schalke 04",
+      "Las Palmas",
+      "Eintracht Frankfurt",
+      "Sassuolo",
+      "Barcelona",
+      "Fiorentina",
+      "Beşiktaş",
+      "Monza",
+      "Hertha BSC"
+    ]
+  },
+  {
+    "id": 652,
+    "name": "Martin Odegaard",
+    "birthdate": "1998-12-17",
+    "club": "Arsenal",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Norway",
+    "past_clubs": [
+      "Strømsgodset",
+      "Real Madrid",
+      "Heerenveen",
+      "Vitesse",
+      "Real Sociedad"
+    ]
+  },
+  {
+    "id": 653,
+    "name": "Conor Gallagher",
+    "birthdate": "2000-02-06",
+    "club": "Atlético Madrid",
+    "league": "La Liga",
+    "position": "Midfielder",
+    "nationality": "England",
+    "past_clubs": [
+      "Chelsea",
+      "Charlton Athletic",
+      "Swansea City",
+      "West Bromwich Albion",
+      "Crystal Palace"
+    ]
+  },
+  {
+    "id": 654,
+    "name": "Gleison Bremer",
+    "birthdate": "1997-03-18",
+    "club": "Juventus",
+    "league": "Serie A",
+    "position": "Defender",
+    "nationality": "Brazil",
+    "past_clubs": [
+      "Desportivo Brasil",
+      "São Paulo",
+      "Atlético Mineiro",
+      "Torino"
+    ]
+  },
+  {
+    "id": 655,
+    "name": "Teun Koopmeiners",
+    "birthdate": "1998-02-28",
+    "club": "Juventus",
+    "league": "Serie A",
+    "position": "Midfielder",
+    "nationality": "Netherlands",
+    "past_clubs": [
+      "AZ Alkmaar",
+      "Atalanta"
+    ]
+  },
+  {
+    "id": 656,
+    "name": "Sergio Ramos",
+    "birthdate": "1986-03-30",
+    "club": "Sevilla",
+    "league": "La Liga",
+    "position": "Defender",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Sevilla",
+      "Real Madrid",
+      "Paris Saint-Germain"
+    ]
+  },
+  {
+    "id": 657,
+    "name": "Thiago Alcântara",
+    "birthdate": "1991-04-11",
+    "club": "Liverpool",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Spain",
+    "past_clubs": [
+      "Barcelona",
+      "Bayern Munich"
+    ]
+  },
+  {
+    "id": 658,
+    "name": "Mesut Özil",
+    "birthdate": "1988-10-15",
+    "club": "Retired",
+    "league": "Sem liga",
+    "position": "Midfielder",
+    "nationality": "Germany",
+    "past_clubs": [
+      "Schalke 04",
+      "Werder Bremen",
+      "Real Madrid",
+      "Arsenal",
+      "Fenerbahçe",
+      "Istanbul Başakşehir"
+    ]
+  },
+  {
+    "id": 660,
+    "name": "João Palhinha",
+    "birthdate": "1995-07-09",
+    "club": "Fulham",
+    "league": "Premier League",
+    "position": "Midfielder",
+    "nationality": "Portugal",
+    "past_clubs": [
+      "Sporting CP",
+      "Moreirense",
+      "Belenenses",
+      "Braga"
+    ]
+  },
+  {
+    "id": 661,
+    "name": "Aleksandar Mitrović",
+    "birthdate": "1994-09-16",
+    "club": "Al Hilal",
+    "league": "Saudi Pro League",
+    "position": "Forward",
+    "nationality": "Serbia",
+    "past_clubs": [
+      "Partizan",
+      "Anderlecht",
+      "Newcastle United",
+      "Fulham"
+    ]
+  },
+  {
+    "id": 662,
+    "name": "Luka Jović",
+    "birthdate": "1997-12-23",
+    "club": "Milan",
+    "league": "Serie A",
+    "position": "Forward",
+    "nationality": "Serbia",
+    "past_clubs": [
+      "Red Star Belgrade",
+      "Benfica",
+      "Eintracht Frankfurt",
+      "Real Madrid",
+      "Fiorentina"
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary
- remove duplicate entries from `players.json`
- update Neymar and Mbappé current clubs
- add new players such as Sergio Ramos and Thiago Alcântara to replace duplicates

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('players.json')); console.log('json valid');"`
- `node - <<'NODE'
const fs=require('fs');
const players=JSON.parse(fs.readFileSync('players.json'));
const map=new Map();
players.forEach(p=>{const key=p.name+'|'+p.birthdate'; map.set(key,(map.get(key)||0)+1);});
console.log('dup count', [...map].filter(([k,v])=>v>1).length);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6840eddc4c648328a2593cb837db1f92