### PR TITLE
Add legend mode, dark theme and hint feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,23 @@
               <span class="slider round"></span>
             </label>
             <span class="mode-label">Modo Difícil</span>
-          </div>          
+          </div>
+        <div class="mode-toggle-container">
+            <span class="mode-label">Atuais</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="legend-toggle">
+              <span class="slider round"></span>
+            </label>
+            <span class="mode-label">Lendas</span>
+        </div>
+        <div class="mode-toggle-container">
+            <span class="mode-label">Claro</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="theme-toggle">
+              <span class="slider round"></span>
+            </label>
+            <span class="mode-label">Escuro</span>
+        </div>
 
         <!-- Modal Tutorial -->
         <div id="tutorial-modal" class="modal">
@@ -62,7 +78,9 @@
         <input type="text" id="player-input" placeholder="Digite o nome do jogador...">
         <ul id="suggestions"></ul>
         <button id="choose-btn" disabled>Escolher</button>
+        <button id="hint-btn" class="info-btn">Dica</button>
         <div id="feedback"></div>
+        <div id="hint" style="margin-top:10px;"></div>
         <div id="player-details" style="display:none;"></div>
         <div id="ranking-container">
             <h3>Seus Melhores Recordes</h3>

--- a/style.css
+++ b/style.css
@@ -446,10 +446,37 @@ button:disabled {
     background: #e65100;
 }
 
+#hint {
+    font-weight: 600;
+    color: #ff9800;
+}
+body.dark-theme #hint {
+    color: #ffb74d;
+}
+
 @media (max-width: 600px) {
     .container {
         width: 95%;
         padding: 20px;
         margin: 20px auto;
     }
+}
+
+/* Tema escuro */
+body.dark-theme {
+    background: #121212;
+    color: #eee;
+}
+body.dark-theme .container {
+    background: #1e1e1e;
+    box-shadow: 0 0 20px rgba(0,0,0,0.4);
+}
+body.dark-theme #instructions {
+    background: #333;
+}
+body.dark-theme button {
+    background: #424242;
+}
+body.dark-theme button:hover {
+    background: #616161;
 }


### PR DESCRIPTION
## Summary
- add toggles for legend mode and dark theme
- add hint button and container
- implement legend mode filtering and hint logic in JS
- store theme and legend settings in localStorage
- style dark theme and hint area

## Testing
- `node -e "require('fs').readFile('main.js','utf8',(e,d)=>{if(e) throw e; new Function(d); console.log('ok');})"`

------
https://chatgpt.com/codex/tasks/task_e_6841f1cda87083288111ee0edf5ce82c