### PR TITLE
Fix duplicate UI and cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,29 +48,6 @@
                 </label>
                 <span class="mode-label">Escuro</span>
             </div>
-        <div class="mode-toggle-container">
-            <span class="mode-label">Modo Normal</span>
-            <label class="toggle-switch">
-              <input type="checkbox" id="mode-toggle">
-              <span class="slider round"></span>
-            </label>
-            <span class="mode-label">Modo Difícil</span>
-          </div>
-        <div class="mode-toggle-container">
-            <span class="mode-label">Atuais</span>
-            <label class="toggle-switch">
-              <input type="checkbox" id="legend-toggle">
-              <span class="slider round"></span>
-            </label>
-            <span class="mode-label">Lendas</span>
-        </div>
-        <div class="mode-toggle-container">
-            <span class="mode-label">Claro</span>
-            <label class="toggle-switch">
-              <input type="checkbox" id="theme-toggle">
-              <span class="slider round"></span>
-            </label>
-            <span class="mode-label">Escuro</span>
         </div>
 
         <!-- Modal Tutorial -->

--- a/main.js
+++ b/main.js
@@ -123,8 +123,6 @@ const UI = {
 
     gameState.quickMode = localStorage.getItem('qs_quick_mode') === 'true';
     if (this.elements.quickToggle) this.elements.quickToggle.checked = gameState.quickMode;
-
-    if (this.elements.legendToggle) this.elements.legendToggle.checked = gameState.legendMode;
     this.updateRanking();
   },
   
@@ -140,8 +138,6 @@ const UI = {
   updateGameStatus() {
     const modeLabel = gameState.mode === 'dificil' ? 'Difícil' : 'Normal';
     const legendLabel = gameState.legendMode ? 'Lendas' : 'Atuais';
-    this.elements.roundInfo.textContent =
-      `Rodada: ${gameState.round} | Acertos: ${gameState.wins} | Vidas: ${gameState.lives} | Recorde: ${gameState.record} | ${modeLabel} | ${legendLabel}`;
     const quickLabel = gameState.quickMode ? 'Rápido' : 'Padrão';
     this.elements.roundInfo.textContent =
       `Rodada: ${gameState.round} | Acertos: ${gameState.wins} | Vidas: ${gameState.lives} | Recorde: ${gameState.record} | ${modeLabel} | ${legendLabel} | ${quickLabel}`;


### PR DESCRIPTION
## Summary
- remove duplicate toggle sections from `index.html`
- fix duplicated legend toggle logic
- simplify `updateGameStatus` text

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684218e4ed088328a5d2d64da560349b